### PR TITLE
update tslint.json

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -16,12 +16,13 @@
     "interface-name": false,
     "jsdoc-format": true,
     "label-position": true,
-    "label-undefined": true,
     "max-line-length": [true, 140],
-    "member-ordering": [true,
-      "public-before-private",
-      "static-before-instance",
-      "variables-before-functions"
+    "member-ordering": [true, {
+        "order": [
+          "public-before-private",
+          "static-before-instance",
+          "variables-before-functions"
+      ]}
     ],
     "no-arg": true,
     "no-bitwise": false,
@@ -33,19 +34,15 @@
       "trace"
     ],
     "no-construct": true,
-    "no-constructor-vars": true,
     "no-debugger": true,
-    "no-duplicate-key": true,
-    "no-duplicate-variable": true,
+    "no-duplicate-variable": false,
     "no-empty": true,
     "no-eval": true,
-    "no-string-literal": false,
     "no-switch-case-fall-through": true,
     "trailing-comma": [true, {"multiline": "never", "singleline": "never"}],
     "no-trailing-whitespace": true,
     "no-unused-expression": true,
     "no-unused-variable": true,
-    "no-unreachable": true,
     "no-use-before-declare": true,
     "no-var-requires": true,
     "one-line": [true,


### PR DESCRIPTION
掲題の通りです。

tslint.json は https://github.com/akashic-games/akashic-engine/blob/v2.0.0/tslint.json に追従していますが、以下のエラーを回避する暫定対応として `"no-string-literal": true,` のみ省いています。

ERROR: src/server/controller/game.ts[4, 26]: object access via string literals is disallowed
