### PR TITLE
add `overflow-y: auto` to developer menu

### DIFF
--- a/css/developer.css
+++ b/css/developer.css
@@ -122,6 +122,7 @@ progress[value]::-webkit-progress-bar {
 
 .dev-menu-body {
   height: 100%;
+  overflow-y: auto;
 }
 
 .dev-menu-view {


### PR DESCRIPTION
デベロッパーツールについて、中身の高さがwindowの100%に固定されているため、
sandbox.config.js で複数のイベントを登録すると、
ディスプレイのサイズによっては下の方が見切れてしまった際に
スクロールすることができないようです。