### PR TITLE
(Overhaul) Implement "Events" tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-sandbox",
-  "version": "1.0.0-refine.0",
+  "version": "1.0.0-refine.1",
   "description": "Standalone runner for Akashic games",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@akashic/akashic-sandbox",
   "private": true,
-  "version": "0.13.4-refine.0",
+  "version": "1.0.0-refine.0",
   "description": "Standalone runner for Akashic games",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -44,16 +44,16 @@
     "mobx": "~3.3.2",
     "mobx-react": "~4.3.5",
     "mobx-react-devtools": "~4.2.15",
-    "react": "~16.1.1",
-    "react-dom": "~16.1.1"
+    "react": "~16.2.0",
+    "react-dom": "~16.2.0"
   },
   "devDependencies": {
     "@types/express": "~4.0.39",
     "@types/jasmine": "~2.8.2",
     "@types/mime": "~2.0.0",
     "@types/node": "~8.0.53",
-    "@types/react": "~16.0.25",
-    "@types/react-dom": "~16.0.3",
+    "@types/react": "~16.0.38",
+    "@types/react-dom": "~16.0.4",
     "@types/supertest": "~2.0.4",
     "awesome-typescript-loader": "~3.4.0",
     "browserify": "^13.0.0",

--- a/src/client/components/Resizable.css
+++ b/src/client/components/Resizable.css
@@ -1,6 +1,6 @@
 .self-right {
 	position: relative;
-	width: calc(100% - 3px);
+	width: 100%;
 	height: 100%;
 }
 	.self-right > .resizer {
@@ -34,6 +34,6 @@
 	}
 	.self-bottom > .content {
 		width: 100%;
-		height: calc(100% - 3px);
+		height: 100%;
 		margin-top: 1px;
 	}

--- a/src/client/containers/CommandBar.css
+++ b/src/client/containers/CommandBar.css
@@ -42,4 +42,3 @@
 		margin: 0 4px;
 		background: var(--tool-border-color);
 	}
-

--- a/src/client/containers/CommandBar.tsx
+++ b/src/client/containers/CommandBar.tsx
@@ -21,10 +21,10 @@ export class CommandBar extends React.Component<CommandBarProps, CommandBarState
 			<span className={styles["icon"] + " fa fa-fw fa-camera"}></span>
 			<div className={styles["splitter"]}></div>
 			<span className={styles["icon"] + " fa xfa-fw fa-fast-backward"}></span>
-			<span className={styles["icon"] + " fa xfa-fw fa-play"}></span>
-			<span className={styles["icon"] + " " + styles["disabled"] + " fa xfa-fw fa-step-forward"}></span>
+			<span className={styles["icon"] + " fa xfa-fw fa-pause"}></span>
+			<span className={styles["icon"] + " disabled" + " fa xfa-fw fa-step-forward"}></span>
 			<div className={styles["splitter"]}></div>
-			<div className={styles["texticon"]}>REPLAY</div>
+			<div className={styles["texticon"]}>REALTIME</div>
 		</div>
 	}
 }

--- a/src/client/containers/EntityDetail.css
+++ b/src/client/containers/EntityDetail.css
@@ -12,7 +12,6 @@
 		position: absolute;
 		width: 100%;
 		height: var(--tool-menubar-height);
-		background: var(--tool-bg-color-white);
 	}
 	.self > .content {
 		box-sizing: border-box;

--- a/src/client/containers/EntityDetail.tsx
+++ b/src/client/containers/EntityDetail.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { action } from "mobx";
 import { observer } from 'mobx-react';
 import { Store } from "../store/Store";
-import { DevtoolUiStore } from "../store/DevtoolUiStore";
+import { SceneToolStore } from "../store/SceneToolStore";
 import { Handlers } from "../handlers/Handlers";
 import { MenuBar } from "../components/MenuBar";
 import { EntityTree } from "./EntityTree";
@@ -18,8 +18,8 @@ export interface EntityDetailProps {
 export class EntityDetail extends React.Component<EntityDetailProps, {}> {
 	render() {
 		const { className, store, handlers } = this.props;
-		const devtoolUiStore = store.devtoolUiStore;
-		const ei = devtoolUiStore.entityTable.get("" + devtoolUiStore.selectedEntityId);
+		const sceneToolStore = store.sceneToolStore;
+		const ei = sceneToolStore.entityTable.get("" + sceneToolStore.selectedEntityId);
 		return <div className={styles["self"] + (className ? (" " + className) : "")}>
 			<MenuBar className={styles["menubar"]}>
 				<span className={"icon fa fa-fw fa-terminal"} title={"Dump to console"} onClick={this._onClickDump} />
@@ -32,7 +32,7 @@ export class EntityDetail extends React.Component<EntityDetailProps, {}> {
 					ei ?
 						<table>
 							<tbody>
-								{ DevtoolUiStore.entityInfoKeys.map(key => <tr key={key}><td>{key}</td><td>{JSON.stringify(ei[key])}</td></tr>) }
+								{ SceneToolStore.entityInfoKeys.map(key => <tr key={key}><td>{key}</td><td>{JSON.stringify(ei[key])}</td></tr>) }
 							</tbody>
 						</table> :
 						null
@@ -43,12 +43,12 @@ export class EntityDetail extends React.Component<EntityDetailProps, {}> {
 
 	private _onClickDump = () => {
 		const { handlers, store } = this.props;
-		handlers.dumpEntity(store.devtoolUiStore.selectedEntityId);
+		handlers.dumpEntity(store.sceneToolStore.selectedEntityId);
 	}
 
 	private _onClickAssign = () => {
 		const { handlers, store } = this.props;
-		handlers.assignToGlobalVariable(store.devtoolUiStore.selectedEntityId);
+		handlers.assignToGlobalVariable(store.sceneToolStore.selectedEntityId);
 	}
 }
 

--- a/src/client/containers/EntityTree.tsx
+++ b/src/client/containers/EntityTree.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {observer} from 'mobx-react';
 import { Store } from "../store/Store";
 import { Handlers } from "../handlers/Handlers";
-import { DevtoolUiStore, EntityInfo } from "../store/DevtoolUiStore";
+import { SceneToolStore, EntityInfo } from "../store/SceneToolStore";
 import { EntityTreeNode } from "./EntityTreeNode";
 import * as styles from "./EntityTree.css";
 
@@ -16,14 +16,14 @@ export interface EntityTreeProps {
 export class EntityTree extends React.Component<EntityTreeProps, {}> {
 	render() {
 		const { store, handlers, className } = this.props;
-		const { devtoolUiStore } = store;
-		const { sceneInfo } = devtoolUiStore;
+		const { sceneToolStore } = store;
+		const { sceneInfo } = sceneToolStore;
 		return <div className={styles["entity-tree"] + (className ? " " + className : "")}>
 			<div className={styles["entity"]}>
 				{ sceneInfo.constructorName }
 				{ sceneInfo.name ? <span className={styles["inline-info"]}> "{sceneInfo.name}"</span> : null }
 			</div>
-			{ sceneInfo.childIds.map(eid => <EntityTreeNode key={eid} devtoolUiStore={devtoolUiStore} eid={eid} handlers={handlers} />) }
+			{ sceneInfo.childIds.map(eid => <EntityTreeNode key={eid} sceneToolStore={sceneToolStore} eid={eid} handlers={handlers} />) }
 		</div>;
 	}
 }

--- a/src/client/containers/EntityTreeNode.tsx
+++ b/src/client/containers/EntityTreeNode.tsx
@@ -2,11 +2,11 @@ import * as React from 'react';
 import {observer} from 'mobx-react';
 import { Store } from "../store/Store";
 import { Handlers } from "../handlers/Handlers";
-import { DevtoolUiStore, EntityInfo } from "../store/DevtoolUiStore";
+import { SceneToolStore, EntityInfo } from "../store/SceneToolStore";
 import * as styles from "./EntityTreeNode.css";
 
 interface EntityTreeChildrenProps {
-	devtoolUiStore: DevtoolUiStore;
+	sceneToolStore: SceneToolStore;
 	handlers: Handlers;
 	eids: number[];
 }
@@ -14,9 +14,9 @@ interface EntityTreeChildrenProps {
 @observer
 class EntityChildren extends React.Component<EntityTreeChildrenProps, {}> {
 	render() {
-		const { devtoolUiStore, handlers, eids } = this.props;
+		const { sceneToolStore, handlers, eids } = this.props;
 		return <div className={styles["nest"]}>
-			{ eids.map(eid => <EntityTreeNode key={eid} devtoolUiStore={devtoolUiStore} handlers={handlers} eid={eid} />) }
+			{ eids.map(eid => <EntityTreeNode key={eid} sceneToolStore={sceneToolStore} handlers={handlers} eid={eid} />) }
 		</div>;
 	}
 }
@@ -50,7 +50,7 @@ class EntityInlineInfo extends React.Component<{ entityInfo: EntityInfo }, {}> {
 }
 
 export interface EntityTreeNodeProps {
-	devtoolUiStore: DevtoolUiStore;
+	sceneToolStore: SceneToolStore;
 	handlers: Handlers;
 	eid: number;
 }
@@ -58,13 +58,13 @@ export interface EntityTreeNodeProps {
 @observer
 export class EntityTreeNode extends React.Component<EntityTreeNodeProps, {}> {
 	render() {
-		const { devtoolUiStore, handlers, eid } = this.props;
-		const ei = devtoolUiStore.entityTable.get("" + eid);
+		const { sceneToolStore, handlers, eid } = this.props;
+		const ei = sceneToolStore.entityTable.get("" + eid);
 		if (!ei)
 			return null;
 		const hasChild = ei.childIds.length > 0;
-		const open = devtoolUiStore.entityExpandTable.get("" + eid);
-		const selected = (eid === devtoolUiStore.selectedEntityId) ? " selected" : "";
+		const open = sceneToolStore.entityExpandTable.get("" + eid);
+		const selected = (eid === sceneToolStore.selectedEntityId) ? " selected" : "";
 		return <div>
 			<div className={styles["entity"] + selected}
 			     onMouseEnter={this._onMouseEnter}
@@ -76,7 +76,7 @@ export class EntityTreeNode extends React.Component<EntityTreeNodeProps, {}> {
 				<EntityInlineInfo entityInfo={ei} />
 			</div>
 			{ (open && ei.childIds.length > 0)
-				? <EntityChildren devtoolUiStore={devtoolUiStore} handlers={handlers} eids={ei.childIds} />
+				? <EntityChildren sceneToolStore={sceneToolStore} handlers={handlers} eids={ei.childIds} />
 				: null }
 		</div>;
 	}

--- a/src/client/containers/EventsTool.css
+++ b/src/client/containers/EventsTool.css
@@ -1,0 +1,10 @@
+.main {
+	overflow-y: scroll;
+	width: 100%;
+	height: 100%;
+}
+.sub {
+	overflow-y: scroll;
+	width: 100%;
+	height: 100%;
+}

--- a/src/client/containers/EventsTool.css
+++ b/src/client/containers/EventsTool.css
@@ -1,10 +1,87 @@
-.main {
-	overflow-y: scroll;
+.self {
+	box-sizing: border-box;
 	width: 100%;
 	height: 100%;
+	font-family: var(--tool-font);
+	font-size: 0.8rem;
+	background: "silver";
 }
-.sub {
-	overflow-y: scroll;
-	width: 100%;
-	height: 100%;
+
+	.self .bar {
+		box-sizing: border-box;
+		width: 100%;
+		padding: 4px;
+		background: var(--tool-bg-color-white);
+	}
+		.self .bar button {
+			margin: 4px;
+			padding: 4px 10px;
+			border: 1px solid var(--tool-border-color);
+			border-radius: 2px;
+			color: var(--tool-color);
+			background: var(--tool-bg-color);
+		}
+		.self .bar button:active {
+			background: var(--tool-bg-color-active);
+		}
+		.self .bar button:hover {
+			color: var(--tool-color-hover);
+		}
+
+	.self .right-aligned {
+		display: flex;
+		justify-content: flex-end;
+	}
+
+	.self > textarea {
+		display: block;
+		width: calc(100% - 2px);
+		min-height: 200px;
+		box-sizing: border-box;
+		padding: 3px;
+		border: 1px solid var(--tool-inner-border-color);
+		border-width: 1px 0;
+		font-family: var(--tool-font-monospace);
+		font-size: 0.8rem;
+		resize: vertical;
+		outline: none;
+	}
+
+	.self table.event-list {
+		width: 100%;
+		border-collapse: collapse;
+	}
+		.self table.event-list > tbody > tr {
+			background: var(--tool-bg-color-white-alt);
+		}
+		.self table.event-list > tbody > tr:nth-child(2n) {
+			background: var(--tool-bg-color-white);
+		}
+			.self table.event-list > tbody > tr > td {
+				font-family: var(--tool-font-monospace);
+				padding: 2px 5px;
+			}
+			.self table.event-list > tbody > tr > td:nth-child(1) {
+				color: var(--akashic-red);
+				width: 40%;
+			}
+
+			.self table.event-list > tbody > tr .hover-only {
+				visibility: hidden;
+			}
+			.self table.event-list > tbody > tr:hover .hover-only {
+				visibility: visible;
+			}
+
+.icon-button {
+	font-family: var(--tool-font-monospace);
+	padding: 3px 7px;
+	margin: 0 1px;
 }
+.icon-button:active {
+	background: var(--tool-bg-color-active);
+}
+.icon-button:hover {
+	color: var(--tool-color-hover);
+}
+

--- a/src/client/containers/EventsTool.tsx
+++ b/src/client/containers/EventsTool.tsx
@@ -3,10 +3,6 @@ import { action } from "mobx";
 import { observer } from 'mobx-react';
 import { Store } from "../store/Store";
 import { Handlers } from "../handlers/Handlers";
-import { VerticalSplitPane } from "../components/VerticalSplitPane";
-import { HorizontalSplitPane } from "../components/HorizontalSplitPane";
-import { EntityTree } from "./EntityTree";
-import { EntityDetail } from "./EntityDetail";
 import * as styles from "./EventsTool.css";
 
 export interface EventsToolProps {
@@ -20,16 +16,59 @@ export interface EventsToolProps {
 export class EventsTool extends React.Component<EventsToolProps, {}> {
 	render() {
 		const { className, store, handlers, vertical } = this.props;
-		if (vertical) {
-			return <VerticalSplitPane className={(className ? (" " + className) : "")}
-			                          initialSecondSize={200}
-			                          first={<EntityTree className={styles["main"]} store={store} handlers={handlers} />}
-			                          second={<EntityDetail className={styles["sub"]} store={store} handlers={handlers} />} />;
-		} else {
-			return <HorizontalSplitPane className={(className ? (" " + className) : "")}
-			                            initialSecondSize={200}
-			                            first={<EntityTree className={styles["main"]} store={store} handlers={handlers} />}
-			                            second={<EntityDetail className={styles["sub"]} store={store} handlers={handlers} />} />;
-		}
+		const eventsTable = store.eventsToolStore.registeredEventsTable;
+		const editorContent = store.eventsToolStore.eventEditorContent;
+		return <div className={styles["self"]}>
+			{ /*
+			<div className={styles["bar"]}>
+				<label><input type="checkbox" checked={false} /> Auto send on startup </label>
+			</div>
+			*/ }
+			<textarea placeholder="An array of events to send (e.g. [[32, 0, null, []], ...])" value={editorContent} onChange={this._onChangeEventEditor} />
+			<div className={`${styles["bar"]} ${styles["right-aligned"]}`}>
+				<button onClick={this._onClickSendEditorContent}><i className="fa fa-external-link"></i> Send Events</button>
+			</div>
+
+			<div style={{overflowY: "scroll"}}>
+				<table className={styles["event-list"]}>
+					<tbody>
+						{
+							Object.keys(eventsTable).map(k => {
+								const pevsText = JSON.stringify(eventsTable[k]);
+								return <tr key={k}>
+									<td>
+										{ k }
+										<span style={{float: "right"}} className={styles["hover-only"]}>
+											<button className={styles["icon-button"]} onClick={() => this._onClickSend(k)}>Send</button>
+											<button className={styles["icon-button"]} onClick={() => this._onClickEdit(k)}>Edit</button>
+										</span>
+									</td>
+									<td> { (pevsText.length > 32) ? (pevsText.slice(0, 29) + "...") : pevsText } </td>
+								</tr>;
+							})
+						}
+					</tbody>
+				</table>
+			</div>
+		</div>;
+	}
+
+	_onClickSend = (name: string) => {
+		const pevs = this.props.store.eventsToolStore.registeredEventsTable[name];
+		this.props.handlers.sendEvents(pevs);
+	}
+
+	_onClickEdit = (name: string) => {
+		const pevs = this.props.store.eventsToolStore.registeredEventsTable[name];
+		this.props.handlers.setEventEditorContent(JSON.stringify(pevs));
+	}
+
+	_onClickSendEditorContent = (ev: React.MouseEvent<HTMLButtonElement>) => {
+		const pevs = JSON.parse(this.props.store.eventsToolStore.eventEditorContent);
+		this.props.handlers.sendEvents(pevs);
+	}
+
+	_onChangeEventEditor = (ev: React.ChangeEvent<HTMLTextAreaElement>) => {
+		this.props.handlers.setEventEditorContent(ev.target.value);
 	}
 }

--- a/src/client/containers/EventsTool.tsx
+++ b/src/client/containers/EventsTool.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { action } from "mobx";
+import { observer } from 'mobx-react';
+import { Store } from "../store/Store";
+import { Handlers } from "../handlers/Handlers";
+import { VerticalSplitPane } from "../components/VerticalSplitPane";
+import { HorizontalSplitPane } from "../components/HorizontalSplitPane";
+import { EntityTree } from "./EntityTree";
+import { EntityDetail } from "./EntityDetail";
+import * as styles from "./SceneTool.css";
+
+export interface SceneToolProps {
+	className?: string;
+	store: Store;
+	handlers: Handlers;
+	vertical: boolean;
+}
+
+@observer
+export class SceneTool extends React.Component<SceneToolProps, {}> {
+	render() {
+		const { className, store, handlers, vertical } = this.props;
+		if (vertical) {
+			return <VerticalSplitPane className={(className ? (" " + className) : "")}
+			                          initialSecondSize={200}
+			                          first={<EntityTree className={styles["main"]} store={store} handlers={handlers} />}
+			                          second={<EntityDetail className={styles["sub"]} store={store} handlers={handlers} />} />;
+		} else {
+			return <HorizontalSplitPane className={(className ? (" " + className) : "")}
+			                            initialSecondSize={200}
+			                            first={<EntityTree className={styles["main"]} store={store} handlers={handlers} />}
+			                            second={<EntityDetail className={styles["sub"]} store={store} handlers={handlers} />} />;
+		}
+	}
+}

--- a/src/client/containers/EventsTool.tsx
+++ b/src/client/containers/EventsTool.tsx
@@ -7,9 +7,9 @@ import { VerticalSplitPane } from "../components/VerticalSplitPane";
 import { HorizontalSplitPane } from "../components/HorizontalSplitPane";
 import { EntityTree } from "./EntityTree";
 import { EntityDetail } from "./EntityDetail";
-import * as styles from "./SceneTool.css";
+import * as styles from "./EventsTool.css";
 
-export interface SceneToolProps {
+export interface EventsToolProps {
 	className?: string;
 	store: Store;
 	handlers: Handlers;
@@ -17,7 +17,7 @@ export interface SceneToolProps {
 }
 
 @observer
-export class SceneTool extends React.Component<SceneToolProps, {}> {
+export class EventsTool extends React.Component<EventsToolProps, {}> {
 	render() {
 		const { className, store, handlers, vertical } = this.props;
 		if (vertical) {

--- a/src/client/containers/Root.tsx
+++ b/src/client/containers/Root.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { action } from "mobx";
 import { observer } from 'mobx-react';
 import { Store, DevtoolType } from "../store/Store";
 import { Handlers } from "../handlers/Handlers";

--- a/src/client/containers/Root.tsx
+++ b/src/client/containers/Root.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { action } from "mobx";
 import { observer } from 'mobx-react';
-import { Store } from "../store/Store";
+import { Store, DevtoolType } from "../store/Store";
 import { Handlers } from "../handlers/Handlers";
 import { Game } from "./Game";
 import { Devtool } from "./Devtool";
@@ -9,6 +9,7 @@ import { CommandBar } from "./CommandBar";
 import { Resizable } from "../components/Resizable";
 import { MenuBar } from "../components/MenuBar";
 import { SceneTool } from "./SceneTool";
+import { EventsTool } from "./EventsTool";
 import * as styles from "./Root.css";
 
 export interface RootProps {
@@ -21,29 +22,58 @@ export class Root extends React.Component<RootProps, {}> {
 	render() {
 		const { store, handlers } = this.props;
 		const pos = store.devtoolPosition;
+		const activeDevtool = store.activeDevtool;
 		const realClassName = styles["devtool"] + " " + styles[(pos === "right") ? "right" : "bottom"];
 		return <div className={styles["root"]}>
-			<CommandBar />
+			{ store.showDevtool ? <CommandBar /> : null }
 			<Game gameStore={store.gameStore} />
-			<Resizable className={realClassName} innerClassName={styles["devtool-inner"]}
-			           initialWidth={store.devtoolWidth} initialHeight={store.devtoolHeight}
-			           pos={pos} onWidthChanged={this._onChangeResizableWidth}>
-				<MenuBar className={styles["menubar"]}>
-					<span className={"icon fa fa-times-circle"} title={"Close"} />
-					<span className={"icon fa " + (pos === "right" ? "fa-toggle-down" : "fa-toggle-right")}
-					      onClick={this._onClickToggleTool} title={"Toggle devtool position"} />
-					<div className="splitter" />
-					<span className="item">Scene</span>
-					<span className="item active">Game</span>
-					<span className="item">Events</span>
-					<span className="item">Storage</span>
-					<span className="item">Settings</span>
-				</MenuBar>
-				<SceneTool className={styles["content"]} store={store} handlers={handlers}
-				           vertical={pos === "right" && store.devtoolWidth < 500} />
-			</Resizable>
+			{
+				store.showDevtool ?
+					<Resizable className={realClassName} innerClassName={styles["devtool-inner"]}
+					           initialWidth={store.devtoolWidth} initialHeight={store.devtoolHeight}
+					           pos={pos} onWidthChanged={this._onChangeResizableWidth}>
+						<MenuBar className={styles["menubar"]}>
+							<span className={"icon fa fa-times-circle"}
+							      title={"Close"}
+							      onClick={() => handlers.closeDevtool() } />
+							<span className={"icon fa " + (pos === "right" ? "fa-toggle-down" : "fa-toggle-right")}
+							      onClick={this._onClickToggleTool} title={"Toggle devtool position"} />
+							<div className="splitter" />
+							<span className={`item ${this._devtoolClassName("Scene")}`} onClick={this._onClickScene}>Scene</span>
+							<span className={`item ${this._devtoolClassName("Game")}`} onClick={this._onClickGame}>Game</span>
+							<span className={`item ${this._devtoolClassName("Events")}`} onClick={this._onClickEvents}>Events</span>
+							<span className={`item ${this._devtoolClassName("Storage")}`} onClick={this._onClickStorage}>Storage</span>
+							<span className={`item ${this._devtoolClassName("Settings")}`} onClick={this._onClickSettings}>Settings</span>
+						</MenuBar>
+						{
+							(activeDevtool === "Scene") ?
+								<SceneTool className={styles["content"]} store={store} handlers={handlers}
+								           vertical={pos === "right" && store.devtoolWidth < 500} /> :
+								null
+						}
+						{
+							(activeDevtool === "Events") ?
+								<EventsTool className={styles["content"]} store={store} handlers={handlers}
+								            vertical={pos === "right" && store.devtoolWidth < 500} /> :
+								null
+						}
+					</Resizable> :
+					<span className={"fa fa-fw fa-cog"}
+					      style={{ position: "fixed", right: 3, top: 3, color: "silver" }}
+					      onClick={() => handlers.openDevtool()} />
+			}
 		</div>;
 	}
+
+	private _devtoolClassName(t: DevtoolType): string {
+		return (this.props.store.activeDevtool === t) ? "active" : "";
+	}
+
+	private _onClickScene = () => { this.props.handlers.setActiveDevtool("Scene"); }
+	private _onClickGame = () => { this.props.handlers.setActiveDevtool("Game"); }
+	private _onClickEvents = () => { this.props.handlers.setActiveDevtool("Events"); }
+	private _onClickStorage = () => { this.props.handlers.setActiveDevtool("Storage"); }
+	private _onClickSettings = () => { this.props.handlers.setActiveDevtool("Settings"); }
 
 	private _onClickToggleTool = () => {
 		const current = this.props.store.devtoolPosition;

--- a/src/client/handlers/Handlers.ts
+++ b/src/client/handlers/Handlers.ts
@@ -1,7 +1,7 @@
 import { action } from 'mobx';
 import { RunnerLike } from "../../runtime/types";
 import { Store, DevtoolPosition } from "../store/Store";
-import { DevtoolUiStore } from "../store/DevtoolUiStore";
+import { SceneToolStore } from "../store/SceneToolStore";
 
 export class Handlers {
 	private _store: Store;
@@ -14,9 +14,9 @@ export class Handlers {
 
 	@action
 	toggleExpandEntity(eid: number): void {
-		const devUiStore = this._store.devtoolUiStore;
-		const current = devUiStore.entityExpandTable.get("" + eid);
-		devUiStore.entityExpandTable.set("" + eid, !current);
+		const sceneToolStore = this._store.sceneToolStore;
+		const current = sceneToolStore.entityExpandTable.get("" + eid);
+		sceneToolStore.entityExpandTable.set("" + eid, !current);
 	}
 
 	@action
@@ -27,7 +27,7 @@ export class Handlers {
 
 	@action
 	selectEntity(eid: number | null): void {
-		this._store.devtoolUiStore.selectedEntityId = eid;
+		this._store.sceneToolStore.selectedEntityId = eid;
 	}
 
 	@action
@@ -41,10 +41,10 @@ export class Handlers {
 	}
 
 	dumpEntity(eid: number): void {
-		console.log(this._store.devtoolUiStore.rawEntityTable[eid]);
+		console.log(this._store.sceneToolStore.rawEntityTable[eid]);
 	}
 
 	assignToGlobalVariable(eid: number): void {
-		(window as any).$e = this._store.devtoolUiStore.rawEntityTable[eid];
+		(window as any).$e = this._store.sceneToolStore.rawEntityTable[eid];
 	}
 }

--- a/src/client/handlers/Handlers.ts
+++ b/src/client/handlers/Handlers.ts
@@ -1,6 +1,6 @@
 import { action } from 'mobx';
 import { RunnerLike } from "../../runtime/types";
-import { Store, DevtoolPosition } from "../store/Store";
+import { Store, DevtoolPosition, DevtoolType } from "../store/Store";
 import { SceneToolStore } from "../store/SceneToolStore";
 
 export class Handlers {
@@ -10,6 +10,21 @@ export class Handlers {
 	constructor(store: Store, runner: RunnerLike) {
 		this._store = store;
 		this._runner = runner;
+	}
+
+	@action
+	openDevtool(): void {
+		this._store.showDevtool = true;
+	}
+
+	@action
+	closeDevtool(): void {
+		this._store.showDevtool = false;
+	}
+
+	@action
+	setActiveDevtool(type: DevtoolType): void {
+		this._store.activeDevtool = type;
 	}
 
 	@action

--- a/src/client/handlers/Handlers.ts
+++ b/src/client/handlers/Handlers.ts
@@ -55,6 +55,15 @@ export class Handlers {
 		this._store.devtoolWidth = w;
 	}
 
+	@action
+	setEventEditorContent(content: string): void {
+		this._store.eventsToolStore.eventEditorContent = content;
+	}
+
+	sendEvents(pevs: any): void {
+		this._runner.sendEvents(pevs);
+	}
+
 	dumpEntity(eid: number): void {
 		console.log(this._store.sceneToolStore.rawEntityTable[eid]);
 	}

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -12,21 +12,45 @@ import "./main.css";
 
 mobx.useStrict(true);
 
+function load(url: string, responseType: XMLHttpRequestResponseType, callback: (error: any, data?: any) => void): void {
+	var request = new XMLHttpRequest();
+	request.open("GET", url, true);
+	request.responseType = responseType;
+	request.timeout = 15000; // TODO ugh! magic number
+	request.addEventListener("timeout", (() => callback(new Error("timeout"))), false);
+	request.addEventListener("load", () => {
+		if (request.status >= 200 && request.status < 300) {
+			var response = responseType === "text" ? request.responseText : request.response;
+			callback(null, response);
+		} else {
+			callback(new Error("loading error. status: " + request.status));
+		}
+	}, false);
+	request.addEventListener("error", (e => callback(e)), false);
+	request.send();
+}
+
 export function main(sbg: AkashicSandboxGlobal) {
-	const watcher = sbg.patchEngine();
-	watcher.start();
+	load("/sandboxconfig", "json", (e, sandboxConfig) => {
+		if (e) {
+			console.error(e);
+			return;
+		}
+		const watcher = sbg.patchEngine();
+		watcher.start();
 
-	const runner = new sbg.Runner({
-		configurationUrl: "/configuration",
-		assetBase: "/game/",
-		nameHash: "dummyGameId",
-		notifyPerformance: true,
-		disablePreventDefaultOnScreen: false
+		const runner = new sbg.Runner({
+			configurationUrl: "/configuration",
+			assetBase: "/game/",
+			nameHash: "dummyGameId",
+			notifyPerformance: true,
+			disablePreventDefaultOnScreen: false
+		});
+
+		const store = new Store(runner, watcher, sandboxConfig);
+		const handlers = new Handlers(store, runner);
+
+		ReactDOM.render(<Root store={store} handlers={handlers} />, document.getElementById('app'));
+		runner.initialize().then(() => runner.start());
 	});
-
-	const store = new Store(runner, watcher);
-	const handlers = new Handlers(store, runner);
-
-	ReactDOM.render(<Root store={store} handlers={handlers} />, document.getElementById('app'));
-	runner.initialize().then(() => runner.start());
 }

--- a/src/client/store/EventsToolStore.ts
+++ b/src/client/store/EventsToolStore.ts
@@ -1,0 +1,12 @@
+import { observable, computed, action, ObservableMap } from 'mobx';
+import { SandboxConfig } from "../../common/SandboxConfig";
+
+export class EventsToolStore {
+	@observable eventEditorContent: string;
+	readonly registeredEventsTable: { [key: string]: any };
+
+	constructor(sandboxConfig: SandboxConfig = {}) {
+		this.eventEditorContent = "";
+		this.registeredEventsTable = (sandboxConfig.events != null) ? sandboxConfig.events : {};
+	}
+}

--- a/src/client/store/SceneToolStore.ts
+++ b/src/client/store/SceneToolStore.ts
@@ -23,7 +23,7 @@ export interface SceneInfo {
 	childIds: number[];
 }
 
-export class DevtoolUiStore {
+export class SceneToolStore {
 	static entityInfoKeys = [
 		"id", "local",
 		"x", "y", "width", "height",

--- a/src/client/store/Store.ts
+++ b/src/client/store/Store.ts
@@ -2,6 +2,8 @@ import { observable } from 'mobx';
 import * as rt from "../../runtime/types";
 import { GameStore } from "./GameStore";
 import { SceneToolStore } from "./SceneToolStore";
+import { EventsToolStore } from "./EventsToolStore";
+import { SandboxConfig } from "../../common/SandboxConfig";
 
 export type DevtoolPosition = "right" | "bottom";
 export type DevtoolType = "Scene" | "Events" | "Game" | "Storage" | "Settings";
@@ -9,6 +11,7 @@ export type DevtoolType = "Scene" | "Events" | "Game" | "Storage" | "Settings";
 export class Store {
 	gameStore: GameStore;
 	sceneToolStore: SceneToolStore;
+	eventsToolStore: EventsToolStore;
 
 	@observable showDevtool: boolean;
 	@observable devtoolPosition: DevtoolPosition;
@@ -16,12 +19,14 @@ export class Store {
 	@observable devtoolHeight: number;
 	@observable activeDevtool: DevtoolType;
 
-	constructor(runner: rt.RunnerLike, watcher: rt.EngineWatcherLike) {
+	constructor(runner: rt.RunnerLike, watcher: rt.EngineWatcherLike, sandboxConfig: SandboxConfig = {}) {
 		this.gameStore = new GameStore(runner);
 		this.sceneToolStore = new SceneToolStore(runner, watcher);
+		this.eventsToolStore = new EventsToolStore(sandboxConfig);
+
+		this.showDevtool = (sandboxConfig.showMenu != null) ? sandboxConfig.showMenu : true;
 
 		// TODO read from storage
-		this.showDevtool = true;
 		this.devtoolPosition = "right";
 		this.devtoolWidth = 400;
 		this.devtoolHeight = 400;

--- a/src/client/store/Store.ts
+++ b/src/client/store/Store.ts
@@ -4,22 +4,27 @@ import { GameStore } from "./GameStore";
 import { SceneToolStore } from "./SceneToolStore";
 
 export type DevtoolPosition = "right" | "bottom";
+export type DevtoolType = "Scene" | "Events" | "Game" | "Storage" | "Settings";
 
 export class Store {
 	gameStore: GameStore;
 	sceneToolStore: SceneToolStore;
 
+	@observable showDevtool: boolean;
 	@observable devtoolPosition: DevtoolPosition;
 	@observable devtoolWidth: number;
 	@observable devtoolHeight: number;
+	@observable activeDevtool: DevtoolType;
 
 	constructor(runner: rt.RunnerLike, watcher: rt.EngineWatcherLike) {
 		this.gameStore = new GameStore(runner);
 		this.sceneToolStore = new SceneToolStore(runner, watcher);
 
 		// TODO read from storage
+		this.showDevtool = true;
 		this.devtoolPosition = "right";
 		this.devtoolWidth = 400;
 		this.devtoolHeight = 400;
+		this.activeDevtool = "Scene";
 	}
 }

--- a/src/client/store/Store.ts
+++ b/src/client/store/Store.ts
@@ -1,13 +1,13 @@
 import { observable } from 'mobx';
 import * as rt from "../../runtime/types";
 import { GameStore } from "./GameStore";
-import { DevtoolUiStore } from "./DevtoolUiStore";
+import { SceneToolStore } from "./SceneToolStore";
 
 export type DevtoolPosition = "right" | "bottom";
 
 export class Store {
 	gameStore: GameStore;
-	devtoolUiStore: DevtoolUiStore;
+	sceneToolStore: SceneToolStore;
 
 	@observable devtoolPosition: DevtoolPosition;
 	@observable devtoolWidth: number;
@@ -15,7 +15,7 @@ export class Store {
 
 	constructor(runner: rt.RunnerLike, watcher: rt.EngineWatcherLike) {
 		this.gameStore = new GameStore(runner);
-		this.devtoolUiStore = new DevtoolUiStore(runner, watcher);
+		this.sceneToolStore = new SceneToolStore(runner, watcher);
 
 		// TODO read from storage
 		this.devtoolPosition = "right";

--- a/src/common/SandboxConfig.ts
+++ b/src/common/SandboxConfig.ts
@@ -1,0 +1,10 @@
+export interface SandboxConfig {
+  /** コンテンツ起動時に流すイベント名(`events` のキーのいずれか) */
+  autoSendEventName?: string;
+
+  /** Eventsツールでリストアップされるイベント */
+  events?: { [key: string]: any };
+
+  /** ページ読み込み時にデベロッパーメニューを開く */
+  showMenu?: boolean;
+}

--- a/src/runtime/types/RunnerLike.ts
+++ b/src/runtime/types/RunnerLike.ts
@@ -11,6 +11,7 @@ export interface RunnerLike {
 	start(): void;
 	setScale(scale: number): void;
 	getBoundingRectData(eid: number): BoundingRectData;
+	sendEvents(pevs: any): void;
 }
 
 export interface RunnerParameterObject {

--- a/src/runtime/v1/RunnerV1.ts
+++ b/src/runtime/v1/RunnerV1.ts
@@ -132,4 +132,8 @@ export class RunnerV1 implements RunnerLike {
 	getBoundingRectData(eid: number): BoundingRectData {
 		return calculateEntityBoundingRect((eid < 0) ? this._game._localDb[eid] : this._game.db[eid]);
 	}
+
+	sendEvents(pevs: any[]): void {
+		pevs.forEach(pev => this._amflow.sendEvent(pev));
+	}
 }

--- a/src/runtime/v2/RunnerV2.ts
+++ b/src/runtime/v2/RunnerV2.ts
@@ -132,4 +132,8 @@ export class RunnerV2 implements RunnerLike {
 	getBoundingRectData(eid: number): BoundingRectData {
 		return calculateEntityBoundingRect((eid < 0) ? this._game._localDb[eid] : this._game.db[eid]);
 	}
+
+	sendEvents(pevs: any[]): void {
+		pevs.forEach(pev => this._amflow.sendEvent(pev));
+	}
 }

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -5,6 +5,7 @@ import { readReuestedRuntimeVersion } from "./util";
 import { createGameRouter } from "./middleware/game";
 import { createConfigurationRouter } from "./middleware/configuration";
 import { createEngineConfRouter } from "./middleware/engine";
+import { createSandboxConfigRouter } from "./middleware/sandboxconfig";
 
 export interface CreateAppParameterObject {
 	gameBase?: string;
@@ -30,15 +31,8 @@ export function createApp(param: CreateAppParameterObject): express.Express {
 		next();
 	});
 
-	// app.use("^\/$", (req, res, next) => {
-	// 	res.redirect("/game/");
-	// });
-	// app.use("^\/game$", (req, res, next) => {
-	// 	res.redirect("/game/");
-	// });
-	// app.use("/css/", express.static(cssBase));
-	// app.use("/thirdparty/", express.static(thridpartyBase));
-	//
+	app.use("^\/?$", (req, res, next) => res.redirect("/game/"));
+	app.use("^\/game?$", (req, res, next) => res.redirect("/game/"));
 	// app.use("/basepath/", (req, res, next) => {
 	// 	res.send(app.gameBase);
 	// });
@@ -54,6 +48,7 @@ export function createApp(param: CreateAppParameterObject): express.Express {
 		app.use("/raw_cascade/" + i, express.static(base));
 	});
 	app.use("/configuration/", createConfigurationRouter({ cascadeLength: cascadeBases.length }));
+	app.use("/sandboxconfig/", createSandboxConfigRouter({ gameBase }));
 	app.use("/engine", createEngineConfRouter({ runtimeVersion }));
 	app.use((req, res, next) => res.sendStatus(404));
 	app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {

--- a/src/server/middleware/sandboxconfig.ts
+++ b/src/server/middleware/sandboxconfig.ts
@@ -1,0 +1,25 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as express from "express";
+
+export interface CreateSandboxConfigRouterParamterObject {
+	gameBase: string;
+}
+
+export function createSandboxConfigRouter(param: CreateSandboxConfigRouterParamterObject): express.Router {
+	const router = express.Router();
+	router.get("/", (req, res, next) => {
+		const configPath = path.resolve(path.join(param.gameBase, "sandbox.config.js"));
+		let sandboxConfig = {};
+		if (fs.existsSync(configPath)) {
+			try {
+				sandboxConfig = require(configPath);
+				delete require.cache[require.resolve(configPath)];
+			} catch (error) {
+				console.log(error);
+			}
+		}
+		res.json(sandboxConfig);
+	});
+	return router;
+}


### PR DESCRIPTION
新 developer ツールに旧ツールの "Events" タブ相当の機能を実装します。

  - イベント編集用 textarea ・送信ボタン
  - sandbox.config.js の events リスト・送信/編集ボタン

主な変更点:

- server: sandbox.config.js をホストする /sandboxconfig/ を追加
- runtime: イベントを流し込む `RunnerLike#sendEvents()` を追加
- client: sandbox.config.js を取得するように。 store/containers/ に Events ツールの実装を追加
- publish 用にバージョンを 1.0.0-refine.0 に

残件:

- localStorage への保持機能 (不要？)
   - 「起動時自動送信」のチェックボックス
- sandbox.config.js の autoSendEvents
- イベントリストをスクロール可能に・リサイズ可能にする
