### PR TITLE
refine ranking-tool

### DIFF
--- a/css/developer.css
+++ b/css/developer.css
@@ -1,8 +1,14 @@
 
 progress[value]::-webkit-progress-bar {
-	background-color: #eee;
-	border-radius: 2px;
-	box-shadow: 0 2px 5px rgba(0, 0, 0, 0.25) inset;
+  background-color: #eee;
+  border-radius: 2px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.25) inset;
+}
+
+.disabled {
+  opacity: 0.3;
+  user-select: none;
+  cursor: default;
 }
 
 .button-success,
@@ -127,6 +133,7 @@ progress[value]::-webkit-progress-bar {
 
 .dev-menu-view {
   height: 100%;
+  padding: 0 1ex;
 }
 
 .dev-menu-contents {

--- a/engine-src/v1/js/developer.js
+++ b/engine-src/v1/js/developer.js
@@ -53,9 +53,9 @@ function setupDeveloperMenu(param) {
 		'events-view': {title: "Events", show: false},
 		'camera-view': {title: "Cameras", show: false},
 		'e-view': {title: "E", show: false},
-		'snapshot-view': {title: "Snapshot", show: false},
 		'niconico-view': {title: "Niconico", show: false},
-		'playlog-view': {title: "Replay", show: false}
+		'playlog-view': {title: "Replay", show: false},
+		'snapshot-view': {title: "Snapshot", show: false}
 	};
 
 	// vue.jsにバインドするデータ

--- a/engine-src/v2/js/developer.js
+++ b/engine-src/v2/js/developer.js
@@ -56,9 +56,9 @@ function setupDeveloperMenu(param) {
 		'events-view': {title: "Events", show: false},
 		'camera-view': {title: "Cameras", show: false},
 		'e-view': {title: "E", show: false},
-		'snapshot-view': {title: "Snapshot", show: false},
 		'niconico-view': {title: "Niconico", show: false},
-		'playlog-view': {title: "Replay", show: false}
+		'playlog-view': {title: "Replay", show: false},
+		'snapshot-view': {title: "Snapshot", show: false}
 	};
 
 	// vue.jsにバインドするデータ

--- a/views/developer.ect
+++ b/views/developer.ect
@@ -189,6 +189,7 @@
 				</table>
 			</div>
 		</div>
+
 		<div class="dev-menu-view" id="e-view">
 			<div class="dev-menu-scroll-contents dev-entity-tree {{ config.isPositionRight ? 'dev-entity-tree-horizontal' : 'dev-entity-tree-vertical' }}">
 				<h2>現在のシーンに属するE</h2>
@@ -226,69 +227,59 @@
 				<p>opacity: {{ targetEntity.opacity }}</p>
 			</div>
 		</div>
-		<div class="dev-menu-view" id="snapshot-view">
-			<div class="dev-menu-contents {{ config.isPositionRight ? 'dev-entity-tree-horizontal' : 'dev-entity-tree-vertical' }}">
-				<h2>スナップショット</h2>
-				<form class="pure-form">
-					<fieldset>
-						<a class="pure-button-primary pure-button" v-on:click="saveSnapshot">スナップショット保存の要求</a>
+
+		<div class="dev-menu-view" id="niconico-view">
+			<div class="dev-menu-contents">
+				<h2>ランキング対応テスト</h2>
+				<p v-if="!isRankingContent">
+					ランキング非対応コンテンツです。
+					ランキングに対応させるためには、game.json の environment フィールドに値を追加する必要があります。
+					詳細は<a href="https://akashic-games.github.io/guide/ranking.html" target="_blank">Webサイト</a>を参照してください。
+				</p>
+				<div class="{{ isRankingContent ? '': 'disabled' }}">
+					<form class="pure-form">
+						<fieldset>
+							<label>
+								<input id="ranking-mode" type="checkbox" v-bind:disabled="!isRankingContent" v-model="config.rankingMode" v-on:change="onRankingModeChanged">
+								<span>ランキングモードの開始イベントを送る(要再起動)</span>
+							</label>
+						</fieldset>
 						<div>
-					</fieldset>
-				</form>
-				<h2>スナップショット一覧</h2>
-				<form class="pure-form">
-					<ul class="dev-snapshot-list">
-						<li v-for="s in snapshots">
-							<span>{{s.name}}</span>
-							<a class="pure-button" v-on:click="previewSnapshot($index, s.name)">プレビュー</a>
-							<a class="pure-button" v-on:click="loadSnapshot(s.name)">復元</a>
-							<a class="pure-button button-error" v-on:click="removeSnapshot(s.name)">削除</a>
-						</li>
-					</ul>
-				</form>
-			</div>
-			<div class="dev-menu-contents {{ config.isPositionRight ? 'dev-entity-property-horizontal' : 'dev-entity-property-vertical' }}">
-				<h2>プレビュー: {{snapshotPreview.name}}</h2>
-				<pre class="dev-snapshot-preview {{ config.isPositionRight ? '' : 'dev-snapshot-preview-vertical' }}">{{snapshotPreview.data}}</pre>
+							totalTimeLimit (秒) <input type="text" v-bind:disabled="!isRankingContent || !config.rankingMode" v-model="config.totalTimeLimit" v-on:change="onTotalTimeLimitChanged">
+						</div>
+						<fieldset>
+							<label>
+								<input id="stop-game" type="checkbox" v-bind:disabled="!isRankingContent || !config.rankingMode" v-model="config.stopsGameOnTimeout" v-on:change="onStopGameChanged">
+								<span>制限時間経過後にゲームを停止</span> (残り{{remainingTime}}秒)
+							</label>
+						</fieldset>
+					</form>
+					<h3>ランキングモードで参照される値</h3>
+					<table class="pure-table">
+						<thead>
+							<tr>
+								<th>g.game.vars.gameState</th>
+								<th>value</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td>score</td>
+								<td>{{ rankingGameState.score }}</td>
+							</tr>
+							<tr>
+								<td>playThreshold</td>
+								<td>{{ rankingGameState.playThreshold }}</td>
+							</tr>
+							<tr>
+								<td>clearThreshold</td>
+								<td>{{ rankingGameState.clearThreshold }}</td>
+							</tr>
+						</tbody>
+					</table>
+				</div>
 			</div>
 		</div>
-        <div class="dev-menu-view" id="niconico-view">
-            <div class="dev-menu-contents">
-                <h2>実験放送テスト</h2>
-                <p v-if="!isRankingContent">
-                    ランキング非対応コンテンツです。
-                    コンテンツをランキングに対応させるためには、game.json の environment フィールドに値を追加する必要があります。
-                    詳細は<a href="https://akashic-games.github.io/guide/ranking.html" target="_blank">akashic公式ページ</a>を参照してください。
-                </p>
-                <div>
-                    <input id="ranking-mode" type="checkbox" v-bind:disabled="!isRankingContent" v-model="config.rankingMode" v-on:change="onRankingModeChanged">
-                    実行開始時にランキングモードの開始イベント (g.MessageEvent) を送る
-                </div>
-                <div>
-                    制限時間設定:<input type="text" v-bind:disabled="!isRankingContent" v-model="config.totalTimeLimit" v-on:change="onTotalTimeLimitChanged">秒
-                </div>
-                <div>
-                    <input id="stop-game" type="checkbox" v-bind:disabled="!isRankingContent" v-model="config.stopsGameOnTimeout" v-on:change="onStopGameChanged">
-                    制限時間経過後にゲームを停止
-                </div>
-                <div>
-                    残り時間:<input type="text" v-model="remainingTime" readonly>
-                </div>
-                <h3>ランキング機能で参照される各変数(g.game.vars.gameState)の値</h3>
-                <div class="pure-g">
-                    <div class="pure-u-1-5">score:</div>
-                    <div class="pure-u-4-5"><input type="text" class="dev-info-text" v-model="rankingGameState.score" readonly></div>
-                </div>
-                <div class="pure-g">
-                    <div class="pure-u-1-5">playThreshold:</div>
-                    <div class="pure-u-4-5"><input type="text" class="dev-info-text" v-model="rankingGameState.playThreshold" readonly></div>
-                </div>
-                <div class="pure-g">
-                    <div class="pure-u-1-5">clearThreshold:</div>
-                    <div class="pure-u-4-5"><input type="text" class="dev-info-text" v-model="rankingGameState.clearThreshold" readonly></div>
-                </div>
-            </div>
-        </div>
 
 		<div class="dev-menu-view" id="playlog-view">
 			<div class="dev-menu-contents">
@@ -330,6 +321,33 @@
 						<input type="file" id="load-playlog-handler">
 					</fieldset>
 				</form>
+			</div>
+		</div>
+
+		<div class="dev-menu-view" id="snapshot-view">
+			<div class="dev-menu-contents {{ config.isPositionRight ? 'dev-entity-tree-horizontal' : 'dev-entity-tree-vertical' }}">
+				<h2>スナップショット</h2>
+				<form class="pure-form">
+					<fieldset>
+						<a class="pure-button-primary pure-button" v-on:click="saveSnapshot">スナップショット保存の要求</a>
+						<div>
+					</fieldset>
+				</form>
+				<h2>スナップショット一覧</h2>
+				<form class="pure-form">
+					<ul class="dev-snapshot-list">
+						<li v-for="s in snapshots">
+							<span>{{s.name}}</span>
+							<a class="pure-button" v-on:click="previewSnapshot($index, s.name)">プレビュー</a>
+							<a class="pure-button" v-on:click="loadSnapshot(s.name)">復元</a>
+							<a class="pure-button button-error" v-on:click="removeSnapshot(s.name)">削除</a>
+						</li>
+					</ul>
+				</form>
+			</div>
+			<div class="dev-menu-contents {{ config.isPositionRight ? 'dev-entity-property-horizontal' : 'dev-entity-property-vertical' }}">
+				<h2>プレビュー: {{snapshotPreview.name}}</h2>
+				<pre class="dev-snapshot-preview {{ config.isPositionRight ? '' : 'dev-snapshot-preview-vertical' }}">{{snapshotPreview.data}}</pre>
 			</div>
 		</div>
 	</div>

--- a/views/game.ect
+++ b/views/game.ect
@@ -26,11 +26,6 @@ window.g = require("@akashic/akashic-engine");
 <script src="/js/v<%= @version %>/developer.js" type="text/javascript"></script>
 <% end %>
 <style>
-* {
-	margin: 0;
-	border: 0;
-	padding: 0;
-}
 body{
 	overflow: hidden;
 	background:#eee;


### PR DESCRIPTION
#76 の UI を調整します。次の点を多少なりとも改善します:

- xnvの提案した文言が、実際入れてみると長すぎて鬱陶しい
- チェックボックスが対応するテキストをクリックしても操作できない
- 少しでも表示幅が狭いと文字がかぶっていて見にくい (「playThreN/A」)
- 文字がぎちぎちに詰まっていて、特にランキング対応の案内とチェックボックスの区別がつかない
- input type=text を使っている意味がほとんどの箇所でない
   - ユーザ入力が可能な場所とそうでない場所で見た目が同じであるべきではない
   - 「制限時間設定:60 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 秒」
- せっかく非対応コンテンツを検出して案内しているのに、使えないUIが有効のまま

### Before/After

<img src="https://user-images.githubusercontent.com/16988148/48398346-d9673b80-e763-11e8-91bf-7587c7165560.png" width="280" /> &nbsp;→&nbsp; <img src="https://user-images.githubusercontent.com/16988148/48398712-e6d0f580-e764-11e8-929a-180f7ca8372e.png" width="280" />

