### PR TITLE
Add preferredSessionParameters.totalTimeLimit to DevTool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.15.23
+* `game.json`の`preferredSessionParameters.TotalTimeLimit`の値を利用するUIを、`DevTool`の`niconico`タブへ追加。
+
 ## 0.15.22
 * 内部コンポーネントの更新
   * v1(engine-files@1.1.13, game-storage@0.0.6)

--- a/engine-src/v1/js/developer.js
+++ b/engine-src/v1/js/developer.js
@@ -73,6 +73,11 @@ function setupDeveloperMenu(param) {
 		'snapshot-view': {title: "Snapshot", show: false}
 	};
 
+	// game.jsonの情報
+	var environment = props.game._configuration.environment;
+	const preferredTotalTimeLimit = !environment || !environment.niconico || !environment.niconico.preferredSessionParameters
+									? defaultTotalTimeLimit : environment.niconico.preferredSessionParameters.totalTimeLimit;
+
 	// vue.jsにバインドするデータ
 	var data = {
 		showMenu: sandboxConfig.showMenu ? sandboxConfig.showMenu : false,
@@ -111,7 +116,6 @@ function setupDeveloperMenu(param) {
 		},
 		views: views,
 		isIchibaContent: function() {
-			var environment = props.game._configuration.environment;
 			if (!environment || !environment.niconico || !environment.niconico.supportedModes) {
 				return false;
 			}
@@ -123,6 +127,7 @@ function setupDeveloperMenu(param) {
 			clearThreshold: "N/A"
 		},
 		remainingTime: "N/A",
+		preferredTotalTimeLimit: preferredTotalTimeLimit,
 		isStopGame: false,
 		modeList: [
 			{text: "ひとりで遊ぶ(single)", value: "single"},
@@ -182,7 +187,7 @@ function setupDeveloperMenu(param) {
 	}
 
 	if (config.sendsSessionParameter && data.isIchibaContent && !param.isReplay) {
-		var totalTimeLimit = parseInt(config.totalTimeLimit, 10);
+		var totalTimeLimit = config.usePreferredTotalTimeLimit ? data.preferredTotalTimeLimit : parseInt(config.totalTimeLimit, 10);
 
 		if (isNaN(totalTimeLimit)) {
 			totalTimeLimit = defaultTotalTimeLimit;
@@ -1189,6 +1194,9 @@ function setupDeveloperMenu(param) {
 				saveConfig();
 			},
 			onStopGameChanged: function() {
+				saveConfig();
+			},
+			onUsePreferredTotalTimeLimitChanged: function () {
 				saveConfig();
 			},
 			toggleGrid: toggleGrid,

--- a/engine-src/v1/js/developer.js
+++ b/engine-src/v1/js/developer.js
@@ -75,8 +75,8 @@ function setupDeveloperMenu(param) {
 
 	// game.jsonの情報
 	var environment = props.game._configuration.environment;
-	const preferredTotalTimeLimit = !environment || !environment.niconico || !environment.niconico.preferredSessionParameters
-									? defaultTotalTimeLimit : environment.niconico.preferredSessionParameters.totalTimeLimit;
+	const preferredTotalTimeLimit = !environment || !environment.niconico || !environment.niconico.preferredSessionParameters || !environment.niconico.preferredSessionParameters.totalTimeLimit
+		? defaultTotalTimeLimit : environment.niconico.preferredSessionParameters.totalTimeLimit;
 
 	// vue.jsにバインドするデータ
 	var data = {

--- a/engine-src/v2/js/developer.js
+++ b/engine-src/v2/js/developer.js
@@ -79,7 +79,7 @@ function setupDeveloperMenu(param) {
 	// game.jsonの情報
 	var environment = props.game._configuration.environment;
 	const preferredTotalTimeLimit = !environment || !environment.niconico || !environment.niconico.preferredSessionParameters || !environment.niconico.preferredSessionParameters.totalTimeLimit
-									? defaultTotalTimeLimit : environment.niconico.preferredSessionParameters.totalTimeLimit;
+		? defaultTotalTimeLimit : environment.niconico.preferredSessionParameters.totalTimeLimit;
 
 	// vue.jsにバインドするデータ
 	var data = {

--- a/engine-src/v2/js/developer.js
+++ b/engine-src/v2/js/developer.js
@@ -76,6 +76,11 @@ function setupDeveloperMenu(param) {
 		'snapshot-view': {title: "Snapshot", show: false}
 	};
 
+	// game.jsonの情報
+	var environment = props.game._configuration.environment;
+	const preferredTotalTimeLimit = !environment || !environment.niconico || !environment.niconico.preferredSessionParameters || !environment.niconico.preferredSessionParameters.totalTimeLimit
+									? defaultTotalTimeLimit : environment.niconico.preferredSessionParameters.totalTimeLimit;
+
 	// vue.jsにバインドするデータ
 	var data = {
 		showMenu: sandboxConfig.showMenu ? sandboxConfig.showMenu : false,
@@ -114,7 +119,6 @@ function setupDeveloperMenu(param) {
 		},
 		views: views,
 		isIchibaContent: function() {
-			var environment = props.game._configuration.environment;
 			if (!environment || !environment.niconico || !environment.niconico.supportedModes) {
 				return false;
 			}
@@ -126,6 +130,7 @@ function setupDeveloperMenu(param) {
 			clearThreshold: "N/A"
 		},
 		remainingTime: "N/A",
+		preferredTotalTimeLimit: preferredTotalTimeLimit,
 		isStopGame: false,
 		modeList: [
 			{text: "ひとりで遊ぶ(single)", value: "single"},
@@ -183,7 +188,7 @@ function setupDeveloperMenu(param) {
 	}
 
 	if (config.sendsSessionParameter && data.isIchibaContent && !param.isReplay) {
-		var totalTimeLimit = parseInt(config.totalTimeLimit, 10);
+		var totalTimeLimit = config.usePreferredTotalTimeLimit ? data.preferredTotalTimeLimit : parseInt(config.totalTimeLimit, 10);
 
 		if (isNaN(totalTimeLimit)) {
 			totalTimeLimit = defaultTotalTimeLimit;
@@ -1202,6 +1207,9 @@ function setupDeveloperMenu(param) {
 				saveConfig();
 			},
 			onStopGameChanged: function() {
+				saveConfig();
+			},
+			onUsePreferredTotalTimeLimitChanged: function () {
 				saveConfig();
 			},
 			toggleGrid: toggleGrid,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-sandbox",
-  "version": "0.15.22",
+  "version": "0.15.23",
   "description": "Standalone runner for Akashic games",
   "main": "index.js",
   "scripts":   {

--- a/views/developer.ejs
+++ b/views/developer.ejs
@@ -278,7 +278,17 @@
 								<td>totalTimeLimit</td>
 								<td>
 									<div>
-										<input type="text" v-model="config.totalTimeLimit" v-on:change="onTotalTimeLimitChanged" />
+										<div v-bind:style="{ color: config.usePreferredTotalTimeLimit ? 'silver' : undefined }">
+											<input type="text" v-model="config.totalTimeLimit" v-on:change="onTotalTimeLimitChanged"
+												v-bind:disabled="config.usePreferredTotalTimeLimit" />
+										</div>
+										<label>
+											<input type="checkbox"
+												v-bind:disabled="!(isIchibaContent && config.mode === 'ranking')"
+												v-model="config.usePreferredTotalTimeLimit"
+												v-on:change="onUsePreferredTotalTimeLimitChanged" />
+											<span>game.jsonのpreferredSessionParametersの値を利用する({{preferredTotalTimeLimit}}秒)</span>
+										</label>
 									</div>
 									<label>
 										<input id="stop-game" type="checkbox" v-bind:disabled="!(isIchibaContent && config.mode === 'ranking')" v-model="config.stopsGameOnTimeout" v-on:change="onStopGameChanged" />


### PR DESCRIPTION
## 修正内容

`game.json` の `preferredSessionParameters.totalTimeLimit` を利用するUIをDevToolの niconicoタブへ追加。

- `preferredSessionParameters.totalTimeLimit`の チェックボックスが有効となる時の動作
  - `totalTimeLimit`値を入力する テキストボックスは `disabled` となる。
  - `時間経過後にゲームを停止(n秒)` の `n` が `preferredSessionParameters.totalTimeLimit`の値でカウントダウンされる。