### PR TITLE
enable to set es6-warning with sandbox.config.js

### DIFF
--- a/engine-src/v1/js/developer.js
+++ b/engine-src/v1/js/developer.js
@@ -42,12 +42,21 @@ function setupDeveloperMenu(param) {
 	if (config.mode == null) {
 		config.mode = "single";
 	}
+
+	var sandboxConfig = window.sandboxDeveloperProps.sandboxConfig;
+
+	// sandbox.config.jsで設定が記述されていたら、対象のチェックボックスを押せないようにする
+	if (sandboxConfig.warn && sandboxConfig.warn.es6 !== undefined) {
+		config.disableWarningEs6 = true;
+		config.warningEs6 = !!sandboxConfig.warn.es6;
+	} else {
+		config.disableWarningEs6 = false;
+	}
+
 	// ES6以降でサポートされるオブジェクトが使われている場合警告を出す。
 	if (config.warningEs6) {
 		warningEs6OnConsole();
 	}
-
-	var sandboxConfig = window.sandboxDeveloperProps.sandboxConfig;
 
 	config.autoSendEvents = config.autoSendEvents || !!sandboxConfig.autoSendEventName;
 	config.eventsToSend = !!sandboxConfig.autoSendEventName ? JSON.stringify(sandboxConfig.events[sandboxConfig.autoSendEventName]) : config.eventsToSend;

--- a/engine-src/v2/js/developer.js
+++ b/engine-src/v2/js/developer.js
@@ -45,12 +45,21 @@ function setupDeveloperMenu(param) {
 	if (config.mode == null) {
 		config.mode = "single";
 	}
+
+	var sandboxConfig = window.sandboxDeveloperProps.sandboxConfig;
+
+	// sandbox.config.jsで設定が記述されていたら、対象のチェックボックスを押せないようにする
+	if (sandboxConfig.warn && sandboxConfig.warn.es6 !== undefined) {
+		config.disableWarningEs6 = true;
+		config.warningEs6 = !!sandboxConfig.warn.es6;
+	} else {
+		config.disableWarningEs6 = false;
+	}
+
 	// ES6以降でサポートされるオブジェクトが使われている場合警告を出す。
 	if (config.warningEs6) {
 		warningEs6OnConsole();
 	}
-
-	var sandboxConfig = window.sandboxDeveloperProps.sandboxConfig;
 
 	config.autoSendEvents = config.autoSendEvents || !!sandboxConfig.autoSendEventName;
 	config.eventsToSend = !!sandboxConfig.autoSendEventName ? JSON.stringify(sandboxConfig.events[sandboxConfig.autoSendEventName]) : config.eventsToSend;

--- a/engine-src/v3/js/developer.js
+++ b/engine-src/v3/js/developer.js
@@ -45,12 +45,21 @@ function setupDeveloperMenu(param) {
 	if (config.mode == null) {
 		config.mode = "single";
 	}
+
+	var sandboxConfig = window.sandboxDeveloperProps.sandboxConfig;
+
+	// sandbox.config.jsで設定が記述されていたら、対象のチェックボックスを押せないようにする
+	if (sandboxConfig.warn && sandboxConfig.warn.es6 !== undefined) {
+		config.disableWarningEs6 = true;
+		config.warningEs6 = !!sandboxConfig.warn.es6;
+	} else {
+		config.disableWarningEs6 = false;
+	}
+
 	// ES6以降でサポートされるオブジェクトが使われている場合警告を出す。
 	if (config.warningEs6) {
 		warningEs6OnConsole();
 	}
-
-	var sandboxConfig = window.sandboxDeveloperProps.sandboxConfig;
 
 	config.autoSendEvents = config.autoSendEvents || !!sandboxConfig.autoSendEventName;
 	config.eventsToSend = !!sandboxConfig.autoSendEventName ? JSON.stringify(sandboxConfig.events[sandboxConfig.autoSendEventName]) : config.eventsToSend;

--- a/src/server/controller/sandboxConfig.ts
+++ b/src/server/controller/sandboxConfig.ts
@@ -30,7 +30,8 @@ function completeConfigParams(c: SandboxConfig): SandboxConfig {
 	var config = {
 		autoSendEventName: c.autoSendEventName ? c.autoSendEventName : "",
 		events: c.events ? c.events : {},
-		showMenu: !!c.showMenu
+		showMenu: !!c.showMenu,
+		warn: c.warn ? c.warn : {}
 	};
 	return config;
 }
@@ -50,4 +51,10 @@ interface SandboxConfig {
 
 	/** ページ読み込み時にデベロッパーメニューを開く */
 	showMenu?: boolean;
+
+	/** 各種警告表示設定 */
+	warn?: {
+		/** ES6以降でサポートされるオブジェクトが使われている場合警告を出すかどうか */
+		es6?: boolean;
+	}
 }

--- a/views/developer.ejs
+++ b/views/developer.ejs
@@ -99,8 +99,8 @@
 							</div>
 							<div>
 								<label for="warning-es6">
-									<input id="warning-es6" type="checkbox" v-model="config.warningEs6" v-on:change="toggleWarningEs6">
-									ES5でサポートされない機能が使用された場合警告を出力
+									<input id="warning-es6" type="checkbox" v-model="config.warningEs6" v-on:change="toggleWarningEs6" v-bind:disabled="config.disableWarningEs6">
+									ES5でサポートされない機能が使用された場合警告を出力<b v-if="config.disableWarningEs6">(sandbox.config.js で<span v-if="config.warningEs6">有効化</span><span v-else>無効化</span>されています)</b>
 								</label>
 							</div>
 							<div>


### PR DESCRIPTION
### 概要
* コンテンツのsandbox.config.jsでES6機能警告表示の設定が行われていたらそちらの設定を優先する対応を行いました(経緯は https://github.com/akashic-games/akashic-cli/pull/488 を参照してください)

### やったこと
* コンテンツのsandbox.config.jsでwarn.es6の設定があった場合、その設定を反映してES6機能警告表示のチェックボックスをdisabledにしました