### PR TITLE
fix error when v3-content stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Unreleased changes
+* ニコニコ新市場対応テストでv3コンテンツを停止する時にエラーになる問題を修正
+
 ## 0.17.2
 * 内部コンポーネントの更新
 * v1(engine-files@1.1.16)

--- a/engine-src/v3/js/developer.js
+++ b/engine-src/v3/js/developer.js
@@ -229,9 +229,7 @@ function setupDeveloperMenu(param) {
 				if (config.stopsGameOnTimeout) {
 					if (props.game && props.game.audio) {
 						// 音を明示的に止める。
-						Object.keys(props.game.audio).forEach(function (key) {
-							props.game.audio[key].stopAll();
-						});
+						props.game.audio.stopAll();
 					}
 					props.driver.stopGame();
 					// akashic-sandboxがゲームを止めたことをユーザーに明示するために、強制的にメニューを開いてメッセージを表示する。


### PR DESCRIPTION
### 概要
* sandboxでv3コンテンツを実行時、「ニコニコ新市場対応テスト」で「時間経過後にゲームを停止 」にチェックを付けた場合停止時にエラーが発生する問題が見つかったので修正する対応を行いました。原因はv3では`Game#audio`がオーディオアセットの連想アセットではなく`AudioSystemManager`オブジェクトに変わったため、全アセットのstopAllメソッドを呼ぼうとしてstopAllメソッドを持たないプロパティを呼び出してしまっていたためです。
