### PR TITLE
Fix renovate minor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,7 @@
         "debug": "^2.1.3",
         "ejs": "~3.1.7",
         "express": "^4.12.3",
-        "express-session": "^1.11.3",
-        "serve-favicon": "^2.2.0"
+        "express-session": "^1.11.3"
       },
       "bin": {
         "akashic-sandbox": "bin/run"
@@ -30,7 +29,6 @@
         "@types/express-session": "~1.17.0",
         "@types/jasmine": "~2.8.2",
         "@types/node": "~14.18.0",
-        "@types/serve-favicon": "~2.5.0",
         "@types/serve-static": "~1.13.1",
         "@types/superagent": "~3.8.0",
         "@types/supertest": "~2.0.4",
@@ -405,15 +403,6 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
-    },
-    "node_modules/@types/serve-favicon": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@types/serve-favicon/-/serve-favicon-2.5.3.tgz",
-      "integrity": "sha512-HirXLRJjLXzwiSnjhE1vMu55X7+qaY+noXsKqi/7eK1uByl3L6TwkcALZuJnQXqOalMdmBz3b662yXvaR+89Vw==",
-      "dev": true,
-      "dependencies": {
-        "@types/express": "*"
-      }
     },
     "node_modules/@types/serve-static": {
       "version": "1.13.10",
@@ -4984,31 +4973,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
-    "node_modules/serve-favicon": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.5.0.tgz",
-      "integrity": "sha512-FMW2RvqNr03x+C0WxTyu6sOv21oOjkq5j8tjquWccwa6ScNyGFOGJVpuS1NmTVGBAHS07xnSKotgf2ehQmf9iA==",
-      "dependencies": {
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "ms": "2.1.1",
-        "parseurl": "~1.3.2",
-        "safe-buffer": "5.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/serve-favicon/node_modules/ms": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-    },
-    "node_modules/serve-favicon/node_modules/safe-buffer": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
-    },
     "node_modules/serve-static": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
@@ -6248,15 +6212,6 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
       "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
-    },
-    "@types/serve-favicon": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/@types/serve-favicon/-/serve-favicon-2.5.3.tgz",
-      "integrity": "sha512-HirXLRJjLXzwiSnjhE1vMu55X7+qaY+noXsKqi/7eK1uByl3L6TwkcALZuJnQXqOalMdmBz3b662yXvaR+89Vw==",
-      "dev": true,
-      "requires": {
-        "@types/express": "*"
-      }
     },
     "@types/serve-static": {
       "version": "1.13.10",
@@ -9742,30 +9697,6 @@
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        }
-      }
-    },
-    "serve-favicon": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.5.0.tgz",
-      "integrity": "sha512-FMW2RvqNr03x+C0WxTyu6sOv21oOjkq5j8tjquWccwa6ScNyGFOGJVpuS1NmTVGBAHS07xnSKotgf2ehQmf9iA==",
-      "requires": {
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "ms": "2.1.1",
-        "parseurl": "~1.3.2",
-        "safe-buffer": "5.1.1"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
     "debug": "^2.1.3",
     "ejs": "~3.1.7",
     "express": "^4.12.3",
-    "express-session": "^1.11.3",
-    "serve-favicon": "^2.2.0"
+    "express-session": "^1.11.3"
   },
   "devDependencies": {
     "@akashic/akashic-engine": "~2.6.6",
@@ -59,7 +58,6 @@
     "@types/express-session": "~1.17.0",
     "@types/jasmine": "~2.8.2",
     "@types/node": "~14.18.0",
-    "@types/serve-favicon": "~2.5.0",
     "@types/serve-static": "~1.13.1",
     "@types/superagent": "~3.8.0",
     "@types/supertest": "~2.0.4",

--- a/renovate.json
+++ b/renovate.json
@@ -42,9 +42,9 @@
       "groupName": "minor dependencies",
       "automerge": true
     },
-	{
-		"matchUpdateTypes": ["major"],
-		"excludePackagePatterns": ["@akashic/akashic-engine"]
-	}
+    {
+        "matchUpdateTypes": ["major"],
+        "excludePackagePatterns": ["@akashic/akashic-engine"]
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -21,16 +21,14 @@
       "schedule": "at any time",
       "groupName": "akashic packages patch",
       "bumpVersion": "patch",
-      "automerge": true,
-      "excludePackagePatterns": ["@akashic/akashic-engine"]
+      "automerge": true
     },
     {
       "matchPackagePatterns": ["^@akashic/"],
       "matchUpdateTypes": ["minor"],
       "schedule": "at any time",
       "groupName": "akashic packages minor",
-      "bumpVersion": "patch",
-      "excludePackagePatterns": ["@akashic/akashic-engine"]
+      "bumpVersion": "patch"
     },
     {
       "matchUpdateTypes": ["patch"],
@@ -43,6 +41,10 @@
       "excludePackagePatterns": ["@akashic/"],
       "groupName": "minor dependencies",
       "automerge": true
-    }
+    },
+	{
+		"matchUpdateTypes": ["major"],
+		"excludePackagePatterns": ["@akashic/akashic-engine"]
+	}
   ]
 }

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -1,8 +1,7 @@
 import fs = require("fs");
 import path = require("path");
 import express = require("express");
-import session = require("express-session");
-// import favicon = require("serve-favicon");
+import * as session  from "express-session";
 import sr = require("./request/ScriptRequest");
 import gameRoute = require("./routes/game");
 import jsRoute = require("./routes/js");
@@ -16,7 +15,7 @@ interface AkashicSandbox extends express.Express {
 	scenario?: any;
 }
 
-interface ASSession extends Express.Session {
+interface ASSession extends session.Session {
 	cntr?: number;
 	results?: any[];
 }


### PR DESCRIPTION
## 概要

renovate の minor 更新で `express-session` が上がり使用方法が変わったためエラーとなった。

その他修正
- 未使用のパッケージを削除
- renovate で akashic-engine の major 更新のみを抑止

#185 へマージします