### PR TITLE
Add groupEngineFiles to renovate.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.19.3
+* `engine-files` のエイリアス名 `aev*` を `engine-files-v*` へ変更
+
 ## 0.19.2
 * 内部モジュールの更新
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ npm run build # src/以下をビルド
 
 akashic-sandbox を用いて内部モジュール (とくに [engine-files](https://github.com/akashic-games/engine-files)) の動作確認を行いたい場合、以下の手順を行ってください。
 
-* package.json で engine-files のエイリアスの `aev1`, `aev2`, `aev3` に対象のバージョンを指定し `npm install` します。インストール後に `npm run copy:engine-files`  を実行することで engine-files が `./js/vX/` へ一括コピーされ動作確認が行える状態となります。
+* package.json で engine-files のエイリアスの `engine-files-v1`, `engine-files-v2`, `engine-files-v3` に対象のバージョンを指定し `npm install` します。インストール後に `npm run copy:engine-files`  を実行することで engine-files が `./js/vX/` へ一括コピーされ動作確認が行える状態となります。
 
 ## 環境変数
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ npm run build # src/以下をビルド
 
 akashic-sandbox を用いて内部モジュール (とくに [engine-files](https://github.com/akashic-games/engine-files)) の動作確認を行いたい場合、以下の手順を行ってください。
 
-* package.json で engine-files のエイリアスの `engine-files-v1`, `engine-files-v2`, `engine-files-v3` に対象のバージョンを指定し `npm install` します。インストール後に `npm run copy:engine-files`  を実行することで engine-files が `./js/vX/` へ一括コピーされ動作確認が行える状態となります。
+* package.json で engine-files のエイリアスの `engine-files-v*` に対象のバージョンを指定し `npm install` します。インストール後に `npm run copy:engine-files`  を実行することで engine-files が `./js/vX/` へ一括コピーされ動作確認が行える状態となります。
 
 ## 環境変数
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.19.2",
       "license": "MIT",
       "dependencies": {
-        "aev1": "npm:@akashic/engine-files@1.2.1",
-        "aev2": "npm:@akashic/engine-files@2.2.1",
-        "aev3": "npm:@akashic/engine-files@3.3.4",
         "commander": "^9.0.0",
         "debug": "^4.0.0",
         "ejs": "~3.1.7",
+        "engine-files-v1": "npm:@akashic/engine-files@1.2.1",
+        "engine-files-v2": "npm:@akashic/engine-files@2.2.1",
+        "engine-files-v3": "npm:@akashic/engine-files@3.3.4",
         "express": "^4.12.3",
         "express-session": "^1.11.3"
       },
@@ -610,118 +610,6 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/aev1": {
-      "name": "@akashic/engine-files",
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@akashic/engine-files/-/engine-files-1.2.1.tgz",
-      "integrity": "sha512-XB9HuBmiA1rQFdc8epWru+a3ix2x+qHz2RkAoRuVwMs1RZmuurLCWMKgRNYMj9fTVNKXzyqyudeJtZCh/jysSw==",
-      "dependencies": {
-        "@akashic/akashic-engine": "1.14.0",
-        "@akashic/akashic-pdi": "1.15.0",
-        "@akashic/game-driver": "0.16.0",
-        "@akashic/pdi-browser": "0.15.0"
-      }
-    },
-    "node_modules/aev1/node_modules/@akashic/akashic-engine": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@akashic/akashic-engine/-/akashic-engine-1.14.0.tgz",
-      "integrity": "sha512-hI/fVUs4yYWClJrYSSbW5DC5rCWQZUIlf1RSAYhye/2CIj7q5O1R0zeOpFE8pJEmYKi8AltiemDFsqAR5rMyMw=="
-    },
-    "node_modules/aev2": {
-      "name": "@akashic/engine-files",
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@akashic/engine-files/-/engine-files-2.2.1.tgz",
-      "integrity": "sha512-m7SoImZZ081eGVNIAIlSkG7FqqfCo4Ssv/aEot+vVw6SgguGs+J85g47JiZbLRIWDpumxLOTBxxn4mTSM1pylA==",
-      "dependencies": {
-        "@akashic/akashic-engine": "2.6.7",
-        "@akashic/akashic-pdi": "2.10.0",
-        "@akashic/game-driver": "1.10.1",
-        "@akashic/pdi-browser": "1.11.1"
-      }
-    },
-    "node_modules/aev2/node_modules/@akashic/akashic-pdi": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@akashic/akashic-pdi/-/akashic-pdi-2.10.0.tgz",
-      "integrity": "sha512-TFLZ9MC369HFRjQGatllk84Qv++0wbKhiM1jUHbZVZQ/0j96ochSBSyyZksPIWt7PxFVl/EnUvOw0+x+TzR9fw==",
-      "dependencies": {
-        "@akashic/akashic-engine": "~2.6.1",
-        "@akashic/amflow": "~3.0.0",
-        "@akashic/playlog": "~3.1.0"
-      }
-    },
-    "node_modules/aev2/node_modules/@akashic/game-driver": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@akashic/game-driver/-/game-driver-1.10.1.tgz",
-      "integrity": "sha512-qpeQdZMsQUIKVwmt8l8n5XyL3cCunlfqQoioGRP5hx2FUuZ5y2mjngY+YsCMYzQLWVmyaq9tswpZgGloQbOLfw==",
-      "dependencies": {
-        "@akashic/akashic-engine": "~2.6.3",
-        "es6-promise": "^4.2.8"
-      }
-    },
-    "node_modules/aev2/node_modules/@akashic/pdi-browser": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@akashic/pdi-browser/-/pdi-browser-1.11.1.tgz",
-      "integrity": "sha512-/fLC8eo1wwi98dUG8EVqskyQWg+7ul7iwuI+fAZ4xdsinC22AW0lQk3AyIQJkNxslOWqhcM+PdglaI3ttgqHTA==",
-      "dependencies": {
-        "@akashic/akashic-engine": "~2.6.3"
-      }
-    },
-    "node_modules/aev3": {
-      "name": "@akashic/engine-files",
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@akashic/engine-files/-/engine-files-3.3.4.tgz",
-      "integrity": "sha512-RoMFZxpFcAKszpIjWdfpMGD6CcXSSazQKCnLiaEKFoI6fF2SKXYTt6pk/+XcvW/GAEv/KbuY+GrI7t5z8fYFTw==",
-      "dependencies": {
-        "@akashic/akashic-engine": "3.6.0",
-        "@akashic/amflow": "3.1.0",
-        "@akashic/amflow-util": "1.1.0",
-        "@akashic/game-configuration": "1.5.0",
-        "@akashic/game-driver": "2.9.0",
-        "@akashic/pdi-browser": "2.3.2",
-        "@akashic/pdi-common-impl": "1.0.0",
-        "@akashic/pdi-types": "1.4.0",
-        "@akashic/playlog": "3.1.0",
-        "@akashic/trigger": "1.0.1"
-      }
-    },
-    "node_modules/aev3/node_modules/@akashic/akashic-engine": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@akashic/akashic-engine/-/akashic-engine-3.6.0.tgz",
-      "integrity": "sha512-/XKvB3zCaZGjCz60CwFYYo4CKsA6b61lXLYsRQJ8l0LA9z6lVHYz9TcjQPnyeiE8JqiVtin8xtJn5zESnmvt/g==",
-      "dependencies": {
-        "@akashic/game-configuration": "~1.5.0",
-        "@akashic/pdi-types": "~1.4.0",
-        "@akashic/playlog": "~3.1.0",
-        "@akashic/trigger": "~1.0.1"
-      }
-    },
-    "node_modules/aev3/node_modules/@akashic/amflow": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@akashic/amflow/-/amflow-3.1.0.tgz",
-      "integrity": "sha512-rruOfUXAQNI8V63dH3BMwZPH5ANKmODWbAohF1LvfrA3UixXDMlV2afLdk8km2wZnD8su3i/JATyWov355lFmQ==",
-      "dependencies": {
-        "@akashic/playlog": "~3.1.0"
-      }
-    },
-    "node_modules/aev3/node_modules/@akashic/game-driver": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@akashic/game-driver/-/game-driver-2.9.0.tgz",
-      "integrity": "sha512-bbeA1EiLR1gndQ+hfWK2G/2V0G/Wga+Wlje+KhnaOZioj5avIxC1fmN8xf/6V1/H0tg/P+jVADeMFcG6pQoTxg==",
-      "dependencies": {
-        "@akashic/akashic-engine": "~3.6.0",
-        "@akashic/amflow-util": "~1.1.0",
-        "@akashic/game-configuration": "~1.5.0",
-        "es6-promise": "^4.2.8"
-      }
-    },
-    "node_modules/aev3/node_modules/@akashic/pdi-browser": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@akashic/pdi-browser/-/pdi-browser-2.3.2.tgz",
-      "integrity": "sha512-LGeVZQOzzL8kEvesJvuUqFLo1R9IJSdK7Rrz/btn9DovHxWP0AZstAK57CKAHdbGpW9FDMhiEYMz4s4+leavcQ==",
-      "dependencies": {
-        "@akashic/trigger": "~1.0.1"
       }
     },
     "node_modules/ajv": {
@@ -1559,6 +1447,118 @@
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/engine-files-v1": {
+      "name": "@akashic/engine-files",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@akashic/engine-files/-/engine-files-1.2.1.tgz",
+      "integrity": "sha512-XB9HuBmiA1rQFdc8epWru+a3ix2x+qHz2RkAoRuVwMs1RZmuurLCWMKgRNYMj9fTVNKXzyqyudeJtZCh/jysSw==",
+      "dependencies": {
+        "@akashic/akashic-engine": "1.14.0",
+        "@akashic/akashic-pdi": "1.15.0",
+        "@akashic/game-driver": "0.16.0",
+        "@akashic/pdi-browser": "0.15.0"
+      }
+    },
+    "node_modules/engine-files-v1/node_modules/@akashic/akashic-engine": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@akashic/akashic-engine/-/akashic-engine-1.14.0.tgz",
+      "integrity": "sha512-hI/fVUs4yYWClJrYSSbW5DC5rCWQZUIlf1RSAYhye/2CIj7q5O1R0zeOpFE8pJEmYKi8AltiemDFsqAR5rMyMw=="
+    },
+    "node_modules/engine-files-v2": {
+      "name": "@akashic/engine-files",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@akashic/engine-files/-/engine-files-2.2.1.tgz",
+      "integrity": "sha512-m7SoImZZ081eGVNIAIlSkG7FqqfCo4Ssv/aEot+vVw6SgguGs+J85g47JiZbLRIWDpumxLOTBxxn4mTSM1pylA==",
+      "dependencies": {
+        "@akashic/akashic-engine": "2.6.7",
+        "@akashic/akashic-pdi": "2.10.0",
+        "@akashic/game-driver": "1.10.1",
+        "@akashic/pdi-browser": "1.11.1"
+      }
+    },
+    "node_modules/engine-files-v2/node_modules/@akashic/akashic-pdi": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@akashic/akashic-pdi/-/akashic-pdi-2.10.0.tgz",
+      "integrity": "sha512-TFLZ9MC369HFRjQGatllk84Qv++0wbKhiM1jUHbZVZQ/0j96ochSBSyyZksPIWt7PxFVl/EnUvOw0+x+TzR9fw==",
+      "dependencies": {
+        "@akashic/akashic-engine": "~2.6.1",
+        "@akashic/amflow": "~3.0.0",
+        "@akashic/playlog": "~3.1.0"
+      }
+    },
+    "node_modules/engine-files-v2/node_modules/@akashic/game-driver": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@akashic/game-driver/-/game-driver-1.10.1.tgz",
+      "integrity": "sha512-qpeQdZMsQUIKVwmt8l8n5XyL3cCunlfqQoioGRP5hx2FUuZ5y2mjngY+YsCMYzQLWVmyaq9tswpZgGloQbOLfw==",
+      "dependencies": {
+        "@akashic/akashic-engine": "~2.6.3",
+        "es6-promise": "^4.2.8"
+      }
+    },
+    "node_modules/engine-files-v2/node_modules/@akashic/pdi-browser": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@akashic/pdi-browser/-/pdi-browser-1.11.1.tgz",
+      "integrity": "sha512-/fLC8eo1wwi98dUG8EVqskyQWg+7ul7iwuI+fAZ4xdsinC22AW0lQk3AyIQJkNxslOWqhcM+PdglaI3ttgqHTA==",
+      "dependencies": {
+        "@akashic/akashic-engine": "~2.6.3"
+      }
+    },
+    "node_modules/engine-files-v3": {
+      "name": "@akashic/engine-files",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/@akashic/engine-files/-/engine-files-3.3.4.tgz",
+      "integrity": "sha512-RoMFZxpFcAKszpIjWdfpMGD6CcXSSazQKCnLiaEKFoI6fF2SKXYTt6pk/+XcvW/GAEv/KbuY+GrI7t5z8fYFTw==",
+      "dependencies": {
+        "@akashic/akashic-engine": "3.6.0",
+        "@akashic/amflow": "3.1.0",
+        "@akashic/amflow-util": "1.1.0",
+        "@akashic/game-configuration": "1.5.0",
+        "@akashic/game-driver": "2.9.0",
+        "@akashic/pdi-browser": "2.3.2",
+        "@akashic/pdi-common-impl": "1.0.0",
+        "@akashic/pdi-types": "1.4.0",
+        "@akashic/playlog": "3.1.0",
+        "@akashic/trigger": "1.0.1"
+      }
+    },
+    "node_modules/engine-files-v3/node_modules/@akashic/akashic-engine": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@akashic/akashic-engine/-/akashic-engine-3.6.0.tgz",
+      "integrity": "sha512-/XKvB3zCaZGjCz60CwFYYo4CKsA6b61lXLYsRQJ8l0LA9z6lVHYz9TcjQPnyeiE8JqiVtin8xtJn5zESnmvt/g==",
+      "dependencies": {
+        "@akashic/game-configuration": "~1.5.0",
+        "@akashic/pdi-types": "~1.4.0",
+        "@akashic/playlog": "~3.1.0",
+        "@akashic/trigger": "~1.0.1"
+      }
+    },
+    "node_modules/engine-files-v3/node_modules/@akashic/amflow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@akashic/amflow/-/amflow-3.1.0.tgz",
+      "integrity": "sha512-rruOfUXAQNI8V63dH3BMwZPH5ANKmODWbAohF1LvfrA3UixXDMlV2afLdk8km2wZnD8su3i/JATyWov355lFmQ==",
+      "dependencies": {
+        "@akashic/playlog": "~3.1.0"
+      }
+    },
+    "node_modules/engine-files-v3/node_modules/@akashic/game-driver": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@akashic/game-driver/-/game-driver-2.9.0.tgz",
+      "integrity": "sha512-bbeA1EiLR1gndQ+hfWK2G/2V0G/Wga+Wlje+KhnaOZioj5avIxC1fmN8xf/6V1/H0tg/P+jVADeMFcG6pQoTxg==",
+      "dependencies": {
+        "@akashic/akashic-engine": "~3.6.0",
+        "@akashic/amflow-util": "~1.1.0",
+        "@akashic/game-configuration": "~1.5.0",
+        "es6-promise": "^4.2.8"
+      }
+    },
+    "node_modules/engine-files-v3/node_modules/@akashic/pdi-browser": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/@akashic/pdi-browser/-/pdi-browser-2.3.2.tgz",
+      "integrity": "sha512-LGeVZQOzzL8kEvesJvuUqFLo1R9IJSdK7Rrz/btn9DovHxWP0AZstAK57CKAHdbGpW9FDMhiEYMz4s4+leavcQ==",
+      "dependencies": {
+        "@akashic/trigger": "~1.0.1"
       }
     },
     "node_modules/es-abstract": {
@@ -6224,121 +6224,6 @@
       "dev": true,
       "requires": {}
     },
-    "aev1": {
-      "version": "npm:@akashic/engine-files@1.2.1",
-      "resolved": "https://registry.npmjs.org/@akashic/engine-files/-/engine-files-1.2.1.tgz",
-      "integrity": "sha512-XB9HuBmiA1rQFdc8epWru+a3ix2x+qHz2RkAoRuVwMs1RZmuurLCWMKgRNYMj9fTVNKXzyqyudeJtZCh/jysSw==",
-      "requires": {
-        "@akashic/akashic-engine": "1.14.0",
-        "@akashic/akashic-pdi": "1.15.0",
-        "@akashic/game-driver": "0.16.0",
-        "@akashic/pdi-browser": "0.15.0"
-      },
-      "dependencies": {
-        "@akashic/akashic-engine": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@akashic/akashic-engine/-/akashic-engine-1.14.0.tgz",
-          "integrity": "sha512-hI/fVUs4yYWClJrYSSbW5DC5rCWQZUIlf1RSAYhye/2CIj7q5O1R0zeOpFE8pJEmYKi8AltiemDFsqAR5rMyMw=="
-        }
-      }
-    },
-    "aev2": {
-      "version": "npm:@akashic/engine-files@2.2.1",
-      "resolved": "https://registry.npmjs.org/@akashic/engine-files/-/engine-files-2.2.1.tgz",
-      "integrity": "sha512-m7SoImZZ081eGVNIAIlSkG7FqqfCo4Ssv/aEot+vVw6SgguGs+J85g47JiZbLRIWDpumxLOTBxxn4mTSM1pylA==",
-      "requires": {
-        "@akashic/akashic-engine": "2.6.7",
-        "@akashic/akashic-pdi": "2.10.0",
-        "@akashic/game-driver": "1.10.1",
-        "@akashic/pdi-browser": "1.11.1"
-      },
-      "dependencies": {
-        "@akashic/akashic-pdi": {
-          "version": "2.10.0",
-          "resolved": "https://registry.npmjs.org/@akashic/akashic-pdi/-/akashic-pdi-2.10.0.tgz",
-          "integrity": "sha512-TFLZ9MC369HFRjQGatllk84Qv++0wbKhiM1jUHbZVZQ/0j96ochSBSyyZksPIWt7PxFVl/EnUvOw0+x+TzR9fw==",
-          "requires": {
-            "@akashic/akashic-engine": "~2.6.1",
-            "@akashic/amflow": "~3.0.0",
-            "@akashic/playlog": "~3.1.0"
-          }
-        },
-        "@akashic/game-driver": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/@akashic/game-driver/-/game-driver-1.10.1.tgz",
-          "integrity": "sha512-qpeQdZMsQUIKVwmt8l8n5XyL3cCunlfqQoioGRP5hx2FUuZ5y2mjngY+YsCMYzQLWVmyaq9tswpZgGloQbOLfw==",
-          "requires": {
-            "@akashic/akashic-engine": "~2.6.3",
-            "es6-promise": "^4.2.8"
-          }
-        },
-        "@akashic/pdi-browser": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npmjs.org/@akashic/pdi-browser/-/pdi-browser-1.11.1.tgz",
-          "integrity": "sha512-/fLC8eo1wwi98dUG8EVqskyQWg+7ul7iwuI+fAZ4xdsinC22AW0lQk3AyIQJkNxslOWqhcM+PdglaI3ttgqHTA==",
-          "requires": {
-            "@akashic/akashic-engine": "~2.6.3"
-          }
-        }
-      }
-    },
-    "aev3": {
-      "version": "npm:@akashic/engine-files@3.3.4",
-      "resolved": "https://registry.npmjs.org/@akashic/engine-files/-/engine-files-3.3.4.tgz",
-      "integrity": "sha512-RoMFZxpFcAKszpIjWdfpMGD6CcXSSazQKCnLiaEKFoI6fF2SKXYTt6pk/+XcvW/GAEv/KbuY+GrI7t5z8fYFTw==",
-      "requires": {
-        "@akashic/akashic-engine": "3.6.0",
-        "@akashic/amflow": "3.1.0",
-        "@akashic/amflow-util": "1.1.0",
-        "@akashic/game-configuration": "1.5.0",
-        "@akashic/game-driver": "2.9.0",
-        "@akashic/pdi-browser": "2.3.2",
-        "@akashic/pdi-common-impl": "1.0.0",
-        "@akashic/pdi-types": "1.4.0",
-        "@akashic/playlog": "3.1.0",
-        "@akashic/trigger": "1.0.1"
-      },
-      "dependencies": {
-        "@akashic/akashic-engine": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/@akashic/akashic-engine/-/akashic-engine-3.6.0.tgz",
-          "integrity": "sha512-/XKvB3zCaZGjCz60CwFYYo4CKsA6b61lXLYsRQJ8l0LA9z6lVHYz9TcjQPnyeiE8JqiVtin8xtJn5zESnmvt/g==",
-          "requires": {
-            "@akashic/game-configuration": "~1.5.0",
-            "@akashic/pdi-types": "~1.4.0",
-            "@akashic/playlog": "~3.1.0",
-            "@akashic/trigger": "~1.0.1"
-          }
-        },
-        "@akashic/amflow": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/@akashic/amflow/-/amflow-3.1.0.tgz",
-          "integrity": "sha512-rruOfUXAQNI8V63dH3BMwZPH5ANKmODWbAohF1LvfrA3UixXDMlV2afLdk8km2wZnD8su3i/JATyWov355lFmQ==",
-          "requires": {
-            "@akashic/playlog": "~3.1.0"
-          }
-        },
-        "@akashic/game-driver": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/@akashic/game-driver/-/game-driver-2.9.0.tgz",
-          "integrity": "sha512-bbeA1EiLR1gndQ+hfWK2G/2V0G/Wga+Wlje+KhnaOZioj5avIxC1fmN8xf/6V1/H0tg/P+jVADeMFcG6pQoTxg==",
-          "requires": {
-            "@akashic/akashic-engine": "~3.6.0",
-            "@akashic/amflow-util": "~1.1.0",
-            "@akashic/game-configuration": "~1.5.0",
-            "es6-promise": "^4.2.8"
-          }
-        },
-        "@akashic/pdi-browser": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/@akashic/pdi-browser/-/pdi-browser-2.3.2.tgz",
-          "integrity": "sha512-LGeVZQOzzL8kEvesJvuUqFLo1R9IJSdK7Rrz/btn9DovHxWP0AZstAK57CKAHdbGpW9FDMhiEYMz4s4+leavcQ==",
-          "requires": {
-            "@akashic/trigger": "~1.0.1"
-          }
-        }
-      }
-    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -6992,6 +6877,121 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
+    },
+    "engine-files-v1": {
+      "version": "npm:@akashic/engine-files@1.2.1",
+      "resolved": "https://registry.npmjs.org/@akashic/engine-files/-/engine-files-1.2.1.tgz",
+      "integrity": "sha512-XB9HuBmiA1rQFdc8epWru+a3ix2x+qHz2RkAoRuVwMs1RZmuurLCWMKgRNYMj9fTVNKXzyqyudeJtZCh/jysSw==",
+      "requires": {
+        "@akashic/akashic-engine": "1.14.0",
+        "@akashic/akashic-pdi": "1.15.0",
+        "@akashic/game-driver": "0.16.0",
+        "@akashic/pdi-browser": "0.15.0"
+      },
+      "dependencies": {
+        "@akashic/akashic-engine": {
+          "version": "1.14.0",
+          "resolved": "https://registry.npmjs.org/@akashic/akashic-engine/-/akashic-engine-1.14.0.tgz",
+          "integrity": "sha512-hI/fVUs4yYWClJrYSSbW5DC5rCWQZUIlf1RSAYhye/2CIj7q5O1R0zeOpFE8pJEmYKi8AltiemDFsqAR5rMyMw=="
+        }
+      }
+    },
+    "engine-files-v2": {
+      "version": "npm:@akashic/engine-files@2.2.1",
+      "resolved": "https://registry.npmjs.org/@akashic/engine-files/-/engine-files-2.2.1.tgz",
+      "integrity": "sha512-m7SoImZZ081eGVNIAIlSkG7FqqfCo4Ssv/aEot+vVw6SgguGs+J85g47JiZbLRIWDpumxLOTBxxn4mTSM1pylA==",
+      "requires": {
+        "@akashic/akashic-engine": "2.6.7",
+        "@akashic/akashic-pdi": "2.10.0",
+        "@akashic/game-driver": "1.10.1",
+        "@akashic/pdi-browser": "1.11.1"
+      },
+      "dependencies": {
+        "@akashic/akashic-pdi": {
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/@akashic/akashic-pdi/-/akashic-pdi-2.10.0.tgz",
+          "integrity": "sha512-TFLZ9MC369HFRjQGatllk84Qv++0wbKhiM1jUHbZVZQ/0j96ochSBSyyZksPIWt7PxFVl/EnUvOw0+x+TzR9fw==",
+          "requires": {
+            "@akashic/akashic-engine": "~2.6.1",
+            "@akashic/amflow": "~3.0.0",
+            "@akashic/playlog": "~3.1.0"
+          }
+        },
+        "@akashic/game-driver": {
+          "version": "1.10.1",
+          "resolved": "https://registry.npmjs.org/@akashic/game-driver/-/game-driver-1.10.1.tgz",
+          "integrity": "sha512-qpeQdZMsQUIKVwmt8l8n5XyL3cCunlfqQoioGRP5hx2FUuZ5y2mjngY+YsCMYzQLWVmyaq9tswpZgGloQbOLfw==",
+          "requires": {
+            "@akashic/akashic-engine": "~2.6.3",
+            "es6-promise": "^4.2.8"
+          }
+        },
+        "@akashic/pdi-browser": {
+          "version": "1.11.1",
+          "resolved": "https://registry.npmjs.org/@akashic/pdi-browser/-/pdi-browser-1.11.1.tgz",
+          "integrity": "sha512-/fLC8eo1wwi98dUG8EVqskyQWg+7ul7iwuI+fAZ4xdsinC22AW0lQk3AyIQJkNxslOWqhcM+PdglaI3ttgqHTA==",
+          "requires": {
+            "@akashic/akashic-engine": "~2.6.3"
+          }
+        }
+      }
+    },
+    "engine-files-v3": {
+      "version": "npm:@akashic/engine-files@3.3.4",
+      "resolved": "https://registry.npmjs.org/@akashic/engine-files/-/engine-files-3.3.4.tgz",
+      "integrity": "sha512-RoMFZxpFcAKszpIjWdfpMGD6CcXSSazQKCnLiaEKFoI6fF2SKXYTt6pk/+XcvW/GAEv/KbuY+GrI7t5z8fYFTw==",
+      "requires": {
+        "@akashic/akashic-engine": "3.6.0",
+        "@akashic/amflow": "3.1.0",
+        "@akashic/amflow-util": "1.1.0",
+        "@akashic/game-configuration": "1.5.0",
+        "@akashic/game-driver": "2.9.0",
+        "@akashic/pdi-browser": "2.3.2",
+        "@akashic/pdi-common-impl": "1.0.0",
+        "@akashic/pdi-types": "1.4.0",
+        "@akashic/playlog": "3.1.0",
+        "@akashic/trigger": "1.0.1"
+      },
+      "dependencies": {
+        "@akashic/akashic-engine": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/@akashic/akashic-engine/-/akashic-engine-3.6.0.tgz",
+          "integrity": "sha512-/XKvB3zCaZGjCz60CwFYYo4CKsA6b61lXLYsRQJ8l0LA9z6lVHYz9TcjQPnyeiE8JqiVtin8xtJn5zESnmvt/g==",
+          "requires": {
+            "@akashic/game-configuration": "~1.5.0",
+            "@akashic/pdi-types": "~1.4.0",
+            "@akashic/playlog": "~3.1.0",
+            "@akashic/trigger": "~1.0.1"
+          }
+        },
+        "@akashic/amflow": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@akashic/amflow/-/amflow-3.1.0.tgz",
+          "integrity": "sha512-rruOfUXAQNI8V63dH3BMwZPH5ANKmODWbAohF1LvfrA3UixXDMlV2afLdk8km2wZnD8su3i/JATyWov355lFmQ==",
+          "requires": {
+            "@akashic/playlog": "~3.1.0"
+          }
+        },
+        "@akashic/game-driver": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/@akashic/game-driver/-/game-driver-2.9.0.tgz",
+          "integrity": "sha512-bbeA1EiLR1gndQ+hfWK2G/2V0G/Wga+Wlje+KhnaOZioj5avIxC1fmN8xf/6V1/H0tg/P+jVADeMFcG6pQoTxg==",
+          "requires": {
+            "@akashic/akashic-engine": "~3.6.0",
+            "@akashic/amflow-util": "~1.1.0",
+            "@akashic/game-configuration": "~1.5.0",
+            "es6-promise": "^4.2.8"
+          }
+        },
+        "@akashic/pdi-browser": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/@akashic/pdi-browser/-/pdi-browser-2.3.2.tgz",
+          "integrity": "sha512-LGeVZQOzzL8kEvesJvuUqFLo1R9IJSdK7Rrz/btn9DovHxWP0AZstAK57CKAHdbGpW9FDMhiEYMz4s4+leavcQ==",
+          "requires": {
+            "@akashic/trigger": "~1.0.1"
+          }
+        }
+      }
     },
     "es-abstract": {
       "version": "1.20.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/akashic-sandbox",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/akashic-sandbox",
-      "version": "0.19.2",
+      "version": "0.19.3",
       "license": "MIT",
       "dependencies": {
         "commander": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-sandbox",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "description": "Standalone runner for Akashic contents",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "@akashic:registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "aev1": "npm:@akashic/engine-files@1.2.1",
-    "aev2": "npm:@akashic/engine-files@2.2.1",
-    "aev3": "npm:@akashic/engine-files@3.3.4",
+    "engine-files-v1": "npm:@akashic/engine-files@1.2.1",
+    "engine-files-v2": "npm:@akashic/engine-files@2.2.1",
+    "engine-files-v3": "npm:@akashic/engine-files@3.3.4",
     "commander": "^9.0.0",
     "debug": "^4.0.0",
     "ejs": "~3.1.7",

--- a/renovate.json
+++ b/renovate.json
@@ -13,12 +13,12 @@
     },
     {
       "matchUpdateTypes": ["patch"],
-      "excludePackagePatterns": ["aev\\d+", "@akashic/", "eslint"],
+      "excludePackagePatterns": ["engine-files-v\\d+", "@akashic/", "eslint"],
       "groupName": "patch dependencies"
     },
     {
       "matchUpdateTypes": ["minor"],
-      "excludePackagePatterns": ["aev\\d+", "@akashic/", "eslint"],
+      "excludePackagePatterns": ["engine-files-v\\d+", "@akashic/", "eslint"],
       "groupName": "minor dependencies"
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -2,74 +2,23 @@
   "extends": [
     "github>akashic-games/renovate-config",
     "github>akashic-games/renovate-config:groupPatchMinor",
-    "github>akashic-games/renovate-config:bumpAkashicPatch"
+    "github>akashic-games/renovate-config:bumpAkashicPatch",
+    "github>akashic-games/renovate-config:groupEngineFiles"
   ],
   "automerge": true,
   "packageRules": [
-    {
-      "matchPackageNames": ["aev1"],
-      "allowedVersions": "<2.0",
-      "groupName": "engine-files@1",
-      "schedule": "at any time"
-    },
-    {
-      "matchPackageNames": ["aev1"],
-      "matchUpdateTypes": ["patch"],
-      "bumpVersion": "patch"
-    },
-    {
-      "matchPackageNames": ["aev1"],
-      "matchUpdateTypes": ["minor"],
-      "bumpVersion": "minor"
-    },
-    {
-      "matchPackageNames": ["aev2"],
-      "allowedVersions": "<3.0",
-      "groupName": "engine-files@2",
-      "schedule": "at any time"
-    },
-    {
-      "matchPackageNames": ["aev2"],
-      "matchUpdateTypes": ["patch"],
-      "bumpVersion": "patch"
-    },
-    {
-      "matchPackageNames": ["aev2"],
-      "matchUpdateTypes": ["minor"],
-      "bumpVersion": "minor"
-    },
-    {
-      "matchPackageNames": ["aev3"],
-      "allowedVersions": "<4.0",
-      "groupName": "engine-files@3",
-      "schedule": "at any time"
-    },
-    {
-      "matchPackageNames": ["aev3"],
-      "matchUpdateTypes": ["patch"],
-      "bumpVersion": "patch"
-    },
-    {
-      "matchPackageNames": ["aev3"],
-      "matchUpdateTypes": ["minor"],
-      "bumpVersion": "minor"
-    },
     {
       "matchPackagePatterns": ["eslint"],
       "groupName": "eslint packages"
     },
     {
-      "matchPackagePatterns": ["jest"],
-      "groupName": "jest packages"
-    },
-    {
       "matchUpdateTypes": ["patch"],
-      "excludePackagePatterns": ["aev\\d+", "@akashic/", "eslint", "jest"],
+      "excludePackagePatterns": ["aev\\d+", "@akashic/", "eslint"],
       "groupName": "patch dependencies"
     },
     {
       "matchUpdateTypes": ["minor"],
-      "excludePackagePatterns": ["aev\\d+", "@akashic/", "eslint", "jest"],
+      "excludePackagePatterns": ["aev\\d+", "@akashic/", "eslint"],
       "groupName": "minor dependencies"
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
     "github>akashic-games/renovate-config",
     "github>akashic-games/renovate-config:groupPatchMinor",
     "github>akashic-games/renovate-config:bumpAkashicPatch",
-    "github>akashic-games/renovate-config:groupEngineFiles"
+    "github>akashic-games/renovate-config//engineFilesAlias/default"
   ],
   "automerge": true,
   "packageRules": [

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -9,7 +9,7 @@ export function resolveEngineFilesVariable(version: SandboxRuntimeVersion): stri
 		engineFilesVariable = filename.replace(/[\.-]/g, "_");
 	} else {
 		// eslint-disable-next-line @typescript-eslint/no-var-requires
-		const engineFilesPkgJson = require(`aev${version}/package.json`);
+		const engineFilesPkgJson = require(`engine-files-v${version}/package.json`);
 		engineFilesVariable = `engineFilesV${engineFilesPkgJson.version.replace(/[\.-]/g, "_")}`;
 	}
 	return engineFilesVariable;
@@ -21,7 +21,7 @@ export function resolveEngineFilesPath(version: SandboxRuntimeVersion): string {
 		engineFilesPath = path.resolve(process.cwd(), process.env.ENGINE_FILES_V3_PATH);
 	} else {
 		const engineFilesName = resolveEngineFilesVariable(version);
-		const libName = `aev${version}`;
+		const libName = `engine-files-v${version}`;
 		engineFilesPath = path.join(path.dirname(require.resolve(libName)), `dist/raw/debug/full/${engineFilesName}.js`);
 	}
 	return engineFilesPath;


### PR DESCRIPTION
## 概要

- renovate-config の `engineFilesAlias/default` を利用します。

- engine-files のエイリアス名 `aev*` を `engine-files-v*` へ変更します。

**動作確認**
エイリアス変更後にコンテンツが動作することを確認