### PR TITLE
support environment.nicolive in akashic-sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Unreleased changes
+* game.jsonの `environtment.nicolive` の値を akashic-sandbox 上で反映できるように
+
 ## 0.21.0
 * 内部モジュールの更新
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased changes
+## 0.21.3
 * game.jsonの `environtment.nicolive` の値を akashic-sandbox 上で反映できるように
 
 ## 0.21.2

--- a/engine-src/v1/js/developer.js
+++ b/engine-src/v1/js/developer.js
@@ -82,9 +82,16 @@ function setupDeveloperMenu(param) {
 	};
 
 	// game.jsonの情報
-	var environment = props.game._configuration.environment;
-	const preferredTotalTimeLimit = !environment || !environment.niconico || !environment.niconico.preferredSessionParameters || !environment.niconico.preferredSessionParameters.totalTimeLimit
-		? defaultTotalTimeLimit : environment.niconico.preferredSessionParameters.totalTimeLimit;
+	function getNicoLiveConfig() {
+		const environment = props.game._configuration.environment;
+		if (environment === undefined) {
+			return null;
+		}
+		// niconico は非推奨なので、nicolive の方を優先的に利用する
+		return environment.nicolive ?? (environment.niconico ?? null);
+	}
+	const nicoliveConfig = getNicoLiveConfig();
+	const preferredTotalTimeLimit = nicoliveConfig?.preferredSessionParameters?.totalTimeLimit ?? defaultTotalTimeLimit;
 
 	// vue.jsにバインドするデータ
 	var data = {
@@ -124,10 +131,10 @@ function setupDeveloperMenu(param) {
 		},
 		views: views,
 		isIchibaContent: function() {
-			if (!environment || !environment.niconico || !environment.niconico.supportedModes) {
+			if (!nicoliveConfig || !nicoliveConfig.supportedModes) {
 				return false;
 			}
-			return environment.niconico.supportedModes.length > 0;
+			return nicoliveConfig.supportedModes.length > 0;
 		}(),
 		rankingGameState: {
 			score: "N/A",

--- a/engine-src/v2/js/developer.js
+++ b/engine-src/v2/js/developer.js
@@ -85,9 +85,16 @@ function setupDeveloperMenu(param) {
 	};
 
 	// game.jsonの情報
-	var environment = props.game._configuration.environment;
-	const preferredTotalTimeLimit = !environment || !environment.niconico || !environment.niconico.preferredSessionParameters || !environment.niconico.preferredSessionParameters.totalTimeLimit
-		? defaultTotalTimeLimit : environment.niconico.preferredSessionParameters.totalTimeLimit;
+	function getNicoLiveConfig() {
+		const environment = props.game._configuration.environment;
+		if (environment === undefined) {
+			return null;
+		}
+		// niconico は非推奨なので、nicolive の方を優先的に利用する
+		return environment.nicolive ?? (environment.niconico ?? null);
+	}
+	const nicoliveConfig = getNicoLiveConfig();
+	const preferredTotalTimeLimit = nicoliveConfig?.preferredSessionParameters?.totalTimeLimit ?? defaultTotalTimeLimit;
 
 	// vue.jsにバインドするデータ
 	var data = {
@@ -127,10 +134,10 @@ function setupDeveloperMenu(param) {
 		},
 		views: views,
 		isIchibaContent: function() {
-			if (!environment || !environment.niconico || !environment.niconico.supportedModes) {
+			if (!nicoliveConfig || !nicoliveConfig.supportedModes) {
 				return false;
 			}
-			return environment.niconico.supportedModes.length > 0;
+			return nicoliveConfig.supportedModes.length > 0;
 		}(),
 		rankingGameState: {
 			score: "N/A",

--- a/engine-src/v3/js/developer.js
+++ b/engine-src/v3/js/developer.js
@@ -85,9 +85,16 @@ function setupDeveloperMenu(param) {
 	};
 
 	// game.jsonの情報
-	var environment = props.game._configuration.environment;
-	const preferredTotalTimeLimit = !environment || !environment.niconico || !environment.niconico.preferredSessionParameters || !environment.niconico.preferredSessionParameters.totalTimeLimit
-		? defaultTotalTimeLimit : environment.niconico.preferredSessionParameters.totalTimeLimit;
+	function getNicoLiveConfig() {
+		const environment = props.game._configuration.environment;
+		if (environment === undefined) {
+			return null;
+		}
+		// niconico は非推奨なので、nicolive の方を優先的に利用する
+		return environment.nicolive ?? (environment.niconico ?? null);
+	}
+	const nicoliveConfig = getNicoLiveConfig();
+	const preferredTotalTimeLimit = nicoliveConfig?.preferredSessionParameters?.totalTimeLimit ?? defaultTotalTimeLimit;
 
 	// vue.jsにバインドするデータ
 	var data = {
@@ -127,10 +134,10 @@ function setupDeveloperMenu(param) {
 		},
 		views: views,
 		isIchibaContent: function() {
-			if (!environment || !environment.niconico || !environment.niconico.supportedModes) {
+			if (!nicoliveConfig || !nicoliveConfig.supportedModes) {
 				return false;
 			}
-			return environment.niconico.supportedModes.length > 0;
+			return nicoliveConfig.supportedModes.length > 0;
 		}(),
 		rankingGameState: {
 			score: "N/A",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/akashic-sandbox",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/akashic-sandbox",
-      "version": "0.21.2",
+      "version": "0.21.3",
       "license": "MIT",
       "dependencies": {
         "commander": "^9.4.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-sandbox",
-  "version": "0.21.2",
+  "version": "0.21.3",
   "description": "Standalone runner for Akashic contents",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### 概要
* コンテンツのgame.jsonの`environment.nicolive`の値がakashic-sandbox上で反映されていなかったので、`environment.nicolive`の値を利用できるように修正を行いました
* 現状だと非推奨の`environment.niconico`のみに対応にしていたので、両方に対応できるようにしました。
  * 両方定義されていた場合はnicoliveの値を優先するようにしています 