### PR TITLE
fix: fix load failure on globalScripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.24.1
+* v0.24.0 で `globalScripts` を持つコンテンツが動作しなくなった問題を修正
+
 ## 0.24.0
 * `ScriptAsset#exports` のサポート
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/akashic-sandbox",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/akashic-sandbox",
-      "version": "0.24.0",
+      "version": "0.24.1",
       "license": "MIT",
       "dependencies": {
         "@akashic/game-configuration": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/akashic-sandbox",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Standalone runner for Akashic contents",
   "main": "index.js",
   "scripts": {

--- a/src/server/controller/js.ts
+++ b/src/server/controller/js.ts
@@ -21,12 +21,12 @@ const controller = (req: sr.ScriptRequest, res: express.Response, next: Function
 	} else {
 		const gameJson: GameConfiguration = JSON.parse(fs.readFileSync(path.join(req.baseDir, "game.json"), { encoding: "utf-8" }));
 		const assetMap = makePathKeyObject(gameJson.assets);
-		const scriptAssetConfig = assetMap[req.params.scriptName] as ScriptAssetConfigurationBase;
+		const scriptAssetConfig = assetMap[req.params.scriptName] as (ScriptAssetConfigurationBase | undefined); // globalScripts の場合 undefined
 		res.render("script", {
 			key: req.originalUrl,
 			scriptContent: content,
 			scriptName: req.params.scriptName,
-			exports: scriptAssetConfig.exports
+			exports: scriptAssetConfig?.exports
 		});
 	}
 };


### PR DESCRIPTION
掲題どおり。

`globalScripts` のあるコンテンツが実行できなくなっている問題を修正します。
原因は game.json 由来の (型検査不能の値) の undefined 考慮漏れでした。

`akashic install @akashic-extension/akashic-timeline` しただけの空のコンテンツがこの修正でエラーにならなくなることを確認しています。
